### PR TITLE
Passing `region` option to `STSClient`

### DIFF
--- a/storage/s3/src/Helpers.ts
+++ b/storage/s3/src/Helpers.ts
@@ -87,7 +87,7 @@ export function createS3Client(config: {
 
 export function createStsClient(config: {
   stsBaseUrl: string;
-  region: string,
+  region: string;
   accessKey: string;
   secretKey: string;
 }): STSClient {


### PR DESCRIPTION
In this PR:
- Fixed the `region` option in `S3ServerSideStorageConfig` usage - passed it through to STSClient. Related to https://github.com/iTwin/object-storage/pull/3