### PR TITLE
Making `Bindable.bindDependencies` protected

### DIFF
--- a/cloud-agnostic/core/src/Bindable.ts
+++ b/cloud-agnostic/core/src/Bindable.ts
@@ -33,8 +33,7 @@ export abstract class Bindable {
     factory.addDependency(dependencyBindings);
   }
 
-  // should be protected but is set public for tests
-  public bindDependencies(container: Container): void {
+  protected bindDependencies(container: Container): void {
     const config = container.get<DependenciesConfig>(Types.dependenciesConfig);
 
     this._dependencyFactories.forEach((factory) => {


### PR DESCRIPTION
In this PR:
- Set the `Bindable.bindDependencies` access level to protected.