### PR TITLE
Removing remaining mentions of `test:integration` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Local development workflows mostly utilize `rush` commands which run a specific 
 ### Running Tests
 
 - `rush test` command runs unit tests for all packages that have unit tests. The tests should pass with no additional setup.
-- `rush test:integration` command runs integration tests for packages that have them. Please see the `IntegrationTests.md` files for instructions specific to each package.
+- `rush test:integration:backend` and `rush test:integration:frontend` commands run integration tests for packages that have them. Please see the `IntegrationTests.md` files for instructions specific to each package.
 
 ## Usage examples
 

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -47,8 +47,8 @@
     {
       "name": "test:integration:backend",
       "commandKind": "bulk",
-      "summary": "Run test:integration script for each package",
-      "description": "Iterates through each package in the monorepo and runs the 'test:integration' script",
+      "summary": "Run test:integration:backend script for each package",
+      "description": "Iterates through each package in the monorepo and runs the 'test:integration:backend' script",
       "enableParallelism": true,
       "ignoreMissingScript": false,
       "allowWarningsInSuccessfulBuild": true

--- a/storage/minio/README.md
+++ b/storage/minio/README.md
@@ -5,10 +5,3 @@ Copyright © Bentley Systems, Incorporated. All rights reserved. See [LICENSE.md
 ## About this package
 
 This package contains implementations for object storage interfaces exposed by `@itwin/object-storage-core` which allow to consume [MinIO](https://min.io/) service. This package extends the `@itwin/object-storage-s3` package and adapts it for MinIO use cases using [MinIO JavaScript Library](https://www.npmjs.com/package/minio).
-
-## Integration tests
-
-Integration test scripts for this package setup the local environment before running the actual tests.
-Users can launch integration tests using the following scripts:
-- `npm run test:integration` will download the MinIO executable based on local operating system, then start the MinIO server and tests. This script is used by "MinIO Integration tests (Environment setup and tests)" VS Code launch configuration.
-- `npm run test:integration:runTests` will only start the tests (without the executable download and MinIO server startup). This script is used by "MinIO Integration tests (Tests only)" VS Code launch configuration to reduce debugging session startup time so make sure that the MinIO server is running locally before launching the session.


### PR DESCRIPTION
In this PR:
- Removed remaining documentation about `test:integration` command.
- Removed "Integration tests" section form MinIO package README.md file since that information is present in IntegrationTests.md file in integration tests folder for this package.