### PR TITLE
`rush` version update and build pipeline improvement

### DIFF
--- a/common/config/azure-pipelines/templates/build-test.yml
+++ b/common/config/azure-pipelines/templates/build-test.yml
@@ -29,38 +29,20 @@ steps:
   - script: node common/scripts/install-run-rush.js test:unit --verbose
     displayName: rush test:unit
 
-  - script: npm run test:integration:backend
-    displayName: npm run test:integration:backend (OSS)
+  - script: node common/scripts/install-run-rush.js test:integration:backend --verbose
+    displayName: rush test:integration:backend
     workingDirectory: storage/oss
     env:
+      TEST_AZURE_STORAGE_ACCOUNT_KEY: $(TEST_AZURE_STORAGE_ACCOUNT_KEY)
       TEST_OSS_ACCESS_KEY: $(TEST_OSS_ACCESS_KEY)
       TEST_OSS_SECRET_KEY: $(TEST_OSS_SECRET_KEY)
       TEST_OSS_ROLE_ARN: $(TEST_OSS_ROLE_ARN)
 
-  - script: npm run test:integration:backend
-    displayName: npm run test:integration:backend (Azure)
-    workingDirectory: storage/azure
-    env:
-      TEST_AZURE_STORAGE_ACCOUNT_KEY: $(TEST_AZURE_STORAGE_ACCOUNT_KEY)
-
-  - script: npm run test:integration:backend
-    displayName: npm run test:integration:backend (MinIO)
-    workingDirectory: storage/minio
-
-  - script: npm run test:integration:frontend
-    displayName: npm run test:integration:frontend (OSS)
+  - script: node common/scripts/install-run-rush.js test:integration:frontend --verbose
+    displayName: rush test:integration:frontend
     workingDirectory: storage/oss
     env:
+      TEST_AZURE_STORAGE_ACCOUNT_KEY: $(TEST_AZURE_STORAGE_ACCOUNT_KEY)
       TEST_OSS_ACCESS_KEY: $(TEST_OSS_ACCESS_KEY)
       TEST_OSS_SECRET_KEY: $(TEST_OSS_SECRET_KEY)
       TEST_OSS_ROLE_ARN: $(TEST_OSS_ROLE_ARN)
-
-  - script: npm run test:integration:frontend
-    displayName: npm run test:integration:frontend (Azure)
-    workingDirectory: storage/azure
-    env:
-      TEST_AZURE_STORAGE_ACCOUNT_KEY: $(TEST_AZURE_STORAGE_ACCOUNT_KEY)
-
-  - script: npm run test:integration:frontend
-    displayName: npm run test:integration:frontend (MinIO)
-    workingDirectory: storage/minio

--- a/common/config/azure-pipelines/templates/build-test.yml
+++ b/common/config/azure-pipelines/templates/build-test.yml
@@ -31,7 +31,6 @@ steps:
 
   - script: node common/scripts/install-run-rush.js test:integration:backend --verbose
     displayName: rush test:integration:backend
-    workingDirectory: storage/oss
     env:
       TEST_AZURE_STORAGE_ACCOUNT_KEY: $(TEST_AZURE_STORAGE_ACCOUNT_KEY)
       TEST_OSS_ACCESS_KEY: $(TEST_OSS_ACCESS_KEY)
@@ -40,7 +39,6 @@ steps:
 
   - script: node common/scripts/install-run-rush.js test:integration:frontend --verbose
     displayName: rush test:integration:frontend
-    workingDirectory: storage/oss
     env:
       TEST_AZURE_STORAGE_ACCOUNT_KEY: $(TEST_AZURE_STORAGE_ACCOUNT_KEY)
       TEST_OSS_ACCESS_KEY: $(TEST_OSS_ACCESS_KEY)

--- a/common/scripts/install-run.js
+++ b/common/scripts/install-run.js
@@ -3,7 +3,11 @@
 // See the @microsoft/rush package's LICENSE file for license information.
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -79,9 +83,9 @@ function _parsePackageSpecifier(rawPackageSpecifier) {
  *
  * IMPORTANT: THIS CODE SHOULD BE KEPT UP TO DATE WITH Utilities.copyAndTrimNpmrcFile()
  */
-function _copyAndTrimNpmrcFile(sourceNpmrcPath, targetNpmrcPath) {
-    console.log(`Transforming ${sourceNpmrcPath}`); // Verbose
-    console.log(`  --> "${targetNpmrcPath}"`);
+function _copyAndTrimNpmrcFile(logger, sourceNpmrcPath, targetNpmrcPath) {
+    logger.info(`Transforming ${sourceNpmrcPath}`); // Verbose
+    logger.info(`  --> "${targetNpmrcPath}"`);
     let npmrcFileLines = fs.readFileSync(sourceNpmrcPath).toString().split('\n');
     npmrcFileLines = npmrcFileLines.map((line) => (line || '').trim());
     const resultLines = [];
@@ -125,16 +129,16 @@ function _copyAndTrimNpmrcFile(sourceNpmrcPath, targetNpmrcPath) {
  *
  * IMPORTANT: THIS CODE SHOULD BE KEPT UP TO DATE WITH Utilities._syncNpmrc()
  */
-function _syncNpmrc(sourceNpmrcFolder, targetNpmrcFolder, useNpmrcPublish) {
+function _syncNpmrc(logger, sourceNpmrcFolder, targetNpmrcFolder, useNpmrcPublish) {
     const sourceNpmrcPath = path.join(sourceNpmrcFolder, !useNpmrcPublish ? '.npmrc' : '.npmrc-publish');
     const targetNpmrcPath = path.join(targetNpmrcFolder, '.npmrc');
     try {
         if (fs.existsSync(sourceNpmrcPath)) {
-            _copyAndTrimNpmrcFile(sourceNpmrcPath, targetNpmrcPath);
+            _copyAndTrimNpmrcFile(logger, sourceNpmrcPath, targetNpmrcPath);
         }
         else if (fs.existsSync(targetNpmrcPath)) {
             // If the source .npmrc doesn't exist and there is one in the target, delete the one in the target
-            console.log(`Deleting ${targetNpmrcPath}`); // Verbose
+            logger.info(`Deleting ${targetNpmrcPath}`); // Verbose
             fs.unlinkSync(targetNpmrcPath);
         }
     }
@@ -215,7 +219,7 @@ function _getRushTempFolder(rushCommonFolder) {
 /**
  * Resolve a package specifier to a static version
  */
-function _resolvePackageVersion(rushCommonFolder, { name, version }) {
+function _resolvePackageVersion(logger, rushCommonFolder, { name, version }) {
     if (!version) {
         version = '*'; // If no version is specified, use the latest version
     }
@@ -229,7 +233,7 @@ function _resolvePackageVersion(rushCommonFolder, { name, version }) {
         try {
             const rushTempFolder = _getRushTempFolder(rushCommonFolder);
             const sourceNpmrcFolder = path.join(rushCommonFolder, 'config', 'rush');
-            _syncNpmrc(sourceNpmrcFolder, rushTempFolder);
+            _syncNpmrc(logger, sourceNpmrcFolder, rushTempFolder);
             const npmPath = getNpmPath();
             // This returns something that looks like:
             //  @microsoft/rush@3.0.0 '3.0.0'
@@ -350,9 +354,9 @@ function _createPackageJson(packageInstallFolder, name, version) {
 /**
  * Run "npm install" in the package install folder.
  */
-function _installPackage(packageInstallFolder, name, version) {
+function _installPackage(logger, packageInstallFolder, name, version) {
     try {
-        console.log(`Installing ${name}...`);
+        logger.info(`Installing ${name}...`);
         const npmPath = getNpmPath();
         const result = childProcess.spawnSync(npmPath, ['install'], {
             stdio: 'inherit',
@@ -362,7 +366,7 @@ function _installPackage(packageInstallFolder, name, version) {
         if (result.status !== 0) {
             throw new Error('"npm install" encountered an error');
         }
-        console.log(`Successfully installed ${name}@${version}`);
+        logger.info(`Successfully installed ${name}@${version}`);
     }
     catch (e) {
         throw new Error(`Unable to install package: ${e}`);
@@ -388,7 +392,7 @@ function _writeFlagFile(packageInstallFolder) {
         throw new Error(`Unable to create installed.flag file in ${packageInstallFolder}`);
     }
 }
-function installAndRun(packageName, packageVersion, packageBinName, packageBinArgs) {
+function installAndRun(logger, packageName, packageVersion, packageBinName, packageBinArgs) {
     const rushJsonFolder = findRushJsonFolder();
     const rushCommonFolder = path.join(rushJsonFolder, 'common');
     const rushTempFolder = _getRushTempFolder(rushCommonFolder);
@@ -397,14 +401,14 @@ function installAndRun(packageName, packageVersion, packageBinName, packageBinAr
         // The package isn't already installed
         _cleanInstallFolder(rushTempFolder, packageInstallFolder);
         const sourceNpmrcFolder = path.join(rushCommonFolder, 'config', 'rush');
-        _syncNpmrc(sourceNpmrcFolder, packageInstallFolder);
+        _syncNpmrc(logger, sourceNpmrcFolder, packageInstallFolder);
         _createPackageJson(packageInstallFolder, packageName, packageVersion);
-        _installPackage(packageInstallFolder, packageName, packageVersion);
+        _installPackage(logger, packageInstallFolder, packageName, packageVersion);
         _writeFlagFile(packageInstallFolder);
     }
     const statusMessage = `Invoking "${packageBinName} ${packageBinArgs.join(' ')}"`;
     const statusMessageLine = new Array(statusMessage.length + 1).join('-');
-    console.log(os.EOL + statusMessage + os.EOL + statusMessageLine + os.EOL);
+    logger.info(os.EOL + statusMessage + os.EOL + statusMessageLine + os.EOL);
     const binPath = _getBinPath(packageInstallFolder, packageBinName);
     const binFolderPath = path.resolve(packageInstallFolder, NODE_MODULES_FOLDER_NAME, '.bin');
     // Windows environment variables are case-insensitive.  Instead of using SpawnSyncOptions.env, we need to
@@ -436,14 +440,14 @@ function installAndRun(packageName, packageVersion, packageBinName, packageBinAr
     }
 }
 exports.installAndRun = installAndRun;
-function runWithErrorAndStatusCode(fn) {
+function runWithErrorAndStatusCode(logger, fn) {
     process.exitCode = 1;
     try {
         const exitCode = fn();
         process.exitCode = exitCode;
     }
     catch (e) {
-        console.error(os.EOL + os.EOL + e.toString() + os.EOL + os.EOL);
+        logger.error(os.EOL + os.EOL + e.toString() + os.EOL + os.EOL);
     }
 }
 exports.runWithErrorAndStatusCode = runWithErrorAndStatusCode;
@@ -462,16 +466,17 @@ function _run() {
         console.log('Example: install-run.js qrcode@1.2.2 qrcode https://rushjs.io');
         process.exit(1);
     }
-    runWithErrorAndStatusCode(() => {
+    const logger = { info: console.log, error: console.error };
+    runWithErrorAndStatusCode(logger, () => {
         const rushJsonFolder = findRushJsonFolder();
         const rushCommonFolder = _ensureAndJoinPath(rushJsonFolder, 'common');
         const packageSpecifier = _parsePackageSpecifier(rawPackageSpecifier);
         const name = packageSpecifier.name;
-        const version = _resolvePackageVersion(rushCommonFolder, packageSpecifier);
+        const version = _resolvePackageVersion(logger, rushCommonFolder, packageSpecifier);
         if (packageSpecifier.version !== version) {
             console.log(`Resolved to ${name}@${version}`);
         }
-        return installAndRun(name, version, packageBinName, packageBinArgs);
+        return installAndRun(logger, name, version, packageBinName, packageBinArgs);
     });
 }
 _run();

--- a/rush.json
+++ b/rush.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
-  "rushVersion": "5.55.1",
+  "rushVersion": "5.68.1",
   "pnpmVersion": "6.13.0",
   "nodeSupportedVersionRange": ">=10.17.0 <15.0.0",
   "ensureConsistentVersions": true,


### PR DESCRIPTION
In this PR:
- Updated rush version from 5.55.1 to 5.68.1. The older version had a bug where custom `rush` commands that contained two semicolons would not work due to missing file in temporary `.rush` folder. That seems to be fixed in the newer version.
- Altered the build pipeline to use `rush test:integration:backend` and `rush test:integration:frontend` commands. This should help avoid situations where new packages or tests are added but the pipeline is not updated to actually run them in PR validation build.