### PR TITLE
`spell-check` command fix

### DIFF
--- a/cloud-agnostic/core/package.json
+++ b/cloud-agnostic/core/package.json
@@ -23,7 +23,7 @@
     "clean": "rimraf lib",
     "lint": "eslint ./src/**/*.ts 1>&2",
     "lint-fix": "eslint --fix ./src/**/*.ts 1>&2 && sort-package-json",
-    "spell-check": "cspell ** --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
+    "spell-check": "cspell \"**\" --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
     "test:integration:backend": "",
     "test:integration:frontend": "",
     "test:unit": "mocha lib/**/*.test.js"

--- a/samples/package.json
+++ b/samples/package.json
@@ -18,7 +18,7 @@
     "clean": "rimraf lib",
     "lint": "eslint ./src/**/*.ts 1>&2",
     "lint-fix": "eslint --fix ./src/**/*.ts 1>&2 && sort-package-json",
-    "spell-check": "cspell ** --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
+    "spell-check": "cspell \"**\" --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
     "test:integration:backend": "",
     "test:integration:frontend": "",
     "test:unit": ""

--- a/storage/azure/package.json
+++ b/storage/azure/package.json
@@ -21,7 +21,7 @@
     "clean": "rimraf lib && rimraf dist",
     "lint": "eslint ./src/**/*.ts 1>&2",
     "lint-fix": "eslint --fix ./src/**/*.ts 1>&2 && sort-package-json",
-    "spell-check": "cspell ** --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
+    "spell-check": "cspell \"**\" --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
     "test:unit": "mocha lib/test/unit/**/*.test.js --color --exit",
     "test:integration:backend": "node lib/test/integration/backend/RunIntegrationTests.js",
     "test:integration:frontend": "npm-run-all -p -r test:integration:frontend:startServer test:integration:frontend:runTests ",

--- a/storage/core/package.json
+++ b/storage/core/package.json
@@ -20,7 +20,7 @@
     "clean": "rimraf lib",
     "lint": "eslint ./src/**/*.ts 1>&2",
     "lint-fix": "eslint --fix ./src/**/*.ts 1>&2 && sort-package-json",
-    "spell-check": "cspell ** --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
+    "spell-check": "cspell \"**\" --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
     "test:integration:backend": "",
     "test:integration:frontend": "",
     "test:unit": "mocha lib/test/**/*.test.js --color --exit"

--- a/storage/minio/package.json
+++ b/storage/minio/package.json
@@ -21,7 +21,7 @@
     "clean": "rimraf lib && rimraf dist",
     "lint": "eslint ./src/**/*.ts 1>&2",
     "lint-fix": "eslint --fix ./src/**/*.ts 1>&2 && sort-package-json",
-    "spell-check": "cspell ** --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
+    "spell-check": "cspell \"**\" --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
     "test:unit": "mocha lib/test/unit/**/*.test.js --color --exit",
     "test:integration:backend": "npm run test:integration:downloadMinio && npm-run-all -p -r test:integration:startMinio test:integration:backend:runTests",
     "test:integration:backend:runTests": "wait-on tcp:9000 -t 30000 && node lib/test/integration/backend/RunIntegrationTests.js",

--- a/storage/oss/package.json
+++ b/storage/oss/package.json
@@ -21,7 +21,7 @@
     "clean": "rimraf lib && rimraf dist",
     "lint": "eslint ./src/**/*.ts 1>&2",
     "lint-fix": "eslint --fix ./src/**/*.ts 1>&2 && sort-package-json",
-    "spell-check": "cspell ** --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
+    "spell-check": "cspell \"**\" --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
     "test:unit": "mocha lib/test/unit/**/*.test.js --color --exit",
     "test:integration:backend": "node lib/test/integration/backend/RunIntegrationTests.js",
     "test:integration:frontend": "npm-run-all -p -r test:integration:frontend:startServer test:integration:frontend:runTests ",

--- a/storage/s3/package.json
+++ b/storage/s3/package.json
@@ -21,7 +21,7 @@
     "clean": "rimraf lib",
     "lint": "eslint ./src/**/*.ts 1>&2",
     "lint-fix": "eslint --fix ./src/**/*.ts 1>&2 && sort-package-json",
-    "spell-check": "cspell ** --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
+    "spell-check": "cspell \"**\" --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
     "test:integration:backend": "",
     "test:integration:frontend": "",
     "test:unit": "mocha lib/test/**/*.test.js --color --exit"

--- a/tests/backend-storage/package.json
+++ b/tests/backend-storage/package.json
@@ -21,7 +21,7 @@
     "clean": "rimraf lib",
     "lint": "eslint ./src/**/*.ts 1>&2",
     "lint-fix": "eslint --fix ./src/**/*.ts 1>&2 && sort-package-json",
-    "spell-check": "cspell ** --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
+    "spell-check": "cspell \"**\" --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
     "test:integration:backend": "",
     "test:integration:frontend": "",
     "test:unit": ""

--- a/tests/frontend-storage/package.json
+++ b/tests/frontend-storage/package.json
@@ -20,7 +20,7 @@
     "clean": "rimraf lib && rimraf cypress/support",
     "lint": "eslint ./src/**/*.ts 1>&2",
     "lint-fix": "eslint --fix ./src/**/*.ts 1>&2 && sort-package-json",
-    "spell-check": "cspell ** --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
+    "spell-check": "cspell \"**\" --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
     "test:integration:backend": "",
     "test:integration:frontend": "",
     "test:unit": ""

--- a/tests/unit/package.json
+++ b/tests/unit/package.json
@@ -20,7 +20,7 @@
     "clean": "rimraf lib",
     "lint": "eslint ./src/**/*.ts 1>&2",
     "lint-fix": "eslint --fix ./src/**/*.ts 1>&2 && sort-package-json",
-    "spell-check": "cspell ** --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
+    "spell-check": "cspell \"**\" --config ./node_modules/@itwin/object-storage-common-config/cspell.json",
     "test:integration:backend": "",
     "test:integration:frontend": "",
     "test:unit": ""


### PR DESCRIPTION
In this PR:
-> Fixed `spell-check` command to specify include path correctly (with quotation marks).