### PR TITLE
Removed `.only` from MinIO unit tests

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -457,6 +457,7 @@ importers:
       eslint-config-prettier: ~8.3.0
       eslint-import-resolver-node: ~0.3.4
       eslint-plugin-import: ~2.22.0
+      eslint-plugin-mocha: ^10.0.4
       eslint-plugin-prettier: ~4.0.0
       prettier: 2.4.1
       sort-package-json: ~1.53.1
@@ -469,6 +470,7 @@ importers:
       eslint-config-prettier: 8.3.0_eslint@7.32.0
       eslint-import-resolver-node: 0.3.6
       eslint-plugin-import: 2.22.1_eslint@7.32.0
+      eslint-plugin-mocha: 10.0.4_eslint@7.32.0
       eslint-plugin-prettier: 4.0.0_6e975bd57c7acf028c1a9ddbbf60c898
       prettier: 2.4.1
       sort-package-json: 1.53.1
@@ -3928,6 +3930,17 @@ packages:
       language-tags: 1.0.5
     dev: true
 
+  /eslint-plugin-mocha/10.0.4_eslint@7.32.0:
+    resolution: {integrity: sha512-8wzAeepVY027oBHz/TmBmUr7vhVqoC1KTFeDybFLhbaWKx+aQ7fJJVuUsqcUy+L+G+XvgQBJY+cbAf7hl5DF7Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      eslint: '>=7.0.0'
+    dependencies:
+      eslint: 7.32.0
+      eslint-utils: 3.0.0_eslint@7.32.0
+      ramda: 0.28.0
+    dev: true
+
   /eslint-plugin-prefer-arrow/1.2.3_eslint@7.32.0:
     resolution: {integrity: sha512-J9I5PKCOJretVuiZRGvPQxCbllxGAV/viI20JO3LYblAodofBxyMnZAJ+WGeClHgANnSJberTNoFWWjrWKBuXQ==}
     peerDependencies:
@@ -6081,6 +6094,10 @@ packages:
 
   /queue-microtask/1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    dev: true
+
+  /ramda/0.28.0:
+    resolution: {integrity: sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==}
     dev: true
 
   /randombytes/2.1.0:

--- a/storage/minio/src/client/MinioClientStorageBindings.ts
+++ b/storage/minio/src/client/MinioClientStorageBindings.ts
@@ -15,6 +15,6 @@ export class MinioClientStorageBindings extends S3ClientStorageBindings {
   public override register(container: Container): void {
     super.register(container);
 
-    container.rebind(ClientStorage).to(MinioClientStorage);
+    container.rebind(ClientStorage).to(MinioClientStorage).inSingletonScope();
   }
 }

--- a/storage/minio/src/frontend/MinioFrontendStorageBindings.ts
+++ b/storage/minio/src/frontend/MinioFrontendStorageBindings.ts
@@ -15,6 +15,9 @@ export class MinioFrontendStorageBindings extends S3FrontendStorageBindings {
   public override register(container: Container): void {
     super.register(container);
 
-    container.rebind(FrontendStorage).to(MinioFrontendStorage);
+    container
+      .rebind(FrontendStorage)
+      .to(MinioFrontendStorage)
+      .inSingletonScope();
   }
 }

--- a/storage/minio/src/test/unit/MinioServerStorageBindings.test.ts
+++ b/storage/minio/src/test/unit/MinioServerStorageBindings.test.ts
@@ -22,7 +22,7 @@ import {
   MinioServerStorageBindings,
 } from "../../server";
 
-describe.only(`${MinioServerStorageBindings.name}`, () => {
+describe(`${MinioServerStorageBindings.name}`, () => {
   const serverBindings = new MinioServerStorageBindings();
 
   describe(`${serverBindings.register.name}()`, () => {

--- a/utils/common-config/.eslintrc.json
+++ b/utils/common-config/.eslintrc.json
@@ -1,7 +1,8 @@
 {
   "parser": "@typescript-eslint/parser",
   "plugins": [
-    "@itwin"
+    "@itwin",
+    "mocha"
   ],
   "extends": [
     "plugin:@itwin/itwinjs-recommended",
@@ -64,6 +65,8 @@
         "caseInsensitive": true
       },
       "newlines-between": "always"
-    }]
+    }],
+    "mocha/no-skipped-tests": "error",
+    "mocha/no-exclusive-tests": "error"
   }
 }

--- a/utils/common-config/package.json
+++ b/utils/common-config/package.json
@@ -30,6 +30,7 @@
     "eslint-config-prettier": "~8.3.0",
     "eslint-import-resolver-node": "~0.3.4",
     "eslint-plugin-import": "~2.22.0",
+    "eslint-plugin-mocha": "^10.0.4",
     "eslint-plugin-prettier": "~4.0.0",
     "prettier": "2.4.1",
     "sort-package-json": "~1.53.1"


### PR DESCRIPTION
In this PR:
- Removed `.only` from MinIO unit tests.
- Fixed the incorrect code that caused newly-enabled tests to fail.
- Added `mocha` ESLint rule so taht linting would fail when `only` or `skip` modifiers are present.