### PR TITLE
Removing `*underTest` from variable/property names

### DIFF
--- a/storage/azure/src/test/unit/AzureClientStorageBindings.test.ts
+++ b/storage/azure/src/test/unit/AzureClientStorageBindings.test.ts
@@ -19,14 +19,13 @@ describe(`${AzureClientStorageBindings.name}`, () => {
   describe(`${clientBindings.register.name}()`, () => {
     const bindingsTestCases: DependencyBindingsTestCase[] = [
       {
-        symbolUnderTestName: ClientStorage.name,
-        functionUnderTest: (container: Container) =>
-          container.get(ClientStorage),
+        testedClassIdentifier: ClientStorage.name,
+        testedFunction: (container: Container) => container.get(ClientStorage),
         expectedCtor: AzureClientStorage,
       },
       {
-        symbolUnderTestName: Types.Client.clientWrapperFactory.toString(),
-        functionUnderTest: (container: Container) =>
+        testedClassIdentifier: Types.Client.clientWrapperFactory.toString(),
+        testedFunction: (container: Container) =>
           container.get<BlockBlobClientWrapperFactory>(
             Types.Client.clientWrapperFactory
           ),

--- a/storage/azure/src/test/unit/AzureFrontendStorageBindings.test.ts
+++ b/storage/azure/src/test/unit/AzureFrontendStorageBindings.test.ts
@@ -22,14 +22,14 @@ describe(`${AzureFrontendStorageBindings.name}`, () => {
   describe(`${frontendBindings.register.name}()`, () => {
     const bindingsTestCases: DependencyBindingsTestCase[] = [
       {
-        symbolUnderTestName: FrontendStorage.name,
-        functionUnderTest: (container: Container) =>
+        testedClassIdentifier: FrontendStorage.name,
+        testedFunction: (container: Container) =>
           container.get(FrontendStorage),
         expectedCtor: AzureFrontendStorage,
       },
       {
-        symbolUnderTestName: Types.Frontend.clientWrapperFactory.toString(),
-        functionUnderTest: (container: Container) =>
+        testedClassIdentifier: Types.Frontend.clientWrapperFactory.toString(),
+        testedFunction: (container: Container) =>
           container.get<BlockBlobClientWrapperFactory>(
             Types.Frontend.clientWrapperFactory
           ),

--- a/storage/azure/src/test/unit/AzureServerStorageBindings.test.ts
+++ b/storage/azure/src/test/unit/AzureServerStorageBindings.test.ts
@@ -60,26 +60,25 @@ describe(`${AzureServerStorageBindings.name}`, () => {
     const bindingsTestCases: DependencyBindingsTestCase[] = [];
     [
       {
-        symbolUnderTestName: ServerStorage.name,
-        functionUnderTest: (container: Container) =>
-          container.get(ServerStorage),
+        testedClassIdentifier: ServerStorage.name,
+        testedFunction: (container: Container) => container.get(ServerStorage),
         expectedCtor: AzureServerStorage,
       },
       {
-        symbolUnderTestName: Types.AzureServer.config.toString(),
-        functionUnderTest: (container: Container) =>
+        testedClassIdentifier: Types.AzureServer.config.toString(),
+        testedFunction: (container: Container) =>
           container.get<AzureServerStorageConfig>(Types.AzureServer.config),
         expectedCtor: Object,
       },
       {
-        symbolUnderTestName: BlobServiceClientWrapper.name,
-        functionUnderTest: (container: Container) =>
+        testedClassIdentifier: BlobServiceClientWrapper.name,
+        testedFunction: (container: Container) =>
           container.get(BlobServiceClientWrapper),
         expectedCtor: BlobServiceClientWrapper,
       },
       {
-        symbolUnderTestName: BlobServiceClient.name,
-        functionUnderTest: (container: Container) =>
+        testedClassIdentifier: BlobServiceClient.name,
+        testedFunction: (container: Container) =>
           container.get(BlobServiceClient),
         expectedCtor: BlobServiceClient,
       },

--- a/storage/minio/src/test/unit/MinioClientStorageBindings.test.ts
+++ b/storage/minio/src/test/unit/MinioClientStorageBindings.test.ts
@@ -18,9 +18,8 @@ describe(`${MinioClientStorageBindings.name}`, () => {
   describe(`${clientBindings.register.name}()`, () => {
     const bindingsTestCases: DependencyBindingsTestCase[] = [
       {
-        symbolUnderTestName: ClientStorage.name,
-        functionUnderTest: (container: Container) =>
-          container.get(ClientStorage),
+        testedClassIdentifier: ClientStorage.name,
+        testedFunction: (container: Container) => container.get(ClientStorage),
         expectedCtor: MinioClientStorage,
       },
     ];

--- a/storage/minio/src/test/unit/MinioFrontendStorageBindings.test.ts
+++ b/storage/minio/src/test/unit/MinioFrontendStorageBindings.test.ts
@@ -21,8 +21,8 @@ describe(`${MinioFrontendStorageBindings.name}`, () => {
   describe(`${frontendBindings.register.name}()`, () => {
     const bindingsTestCases: DependencyBindingsTestCase[] = [
       {
-        symbolUnderTestName: FrontendStorage.name,
-        functionUnderTest: (container: Container) =>
+        testedClassIdentifier: FrontendStorage.name,
+        testedFunction: (container: Container) =>
           container.get(FrontendStorage),
         expectedCtor: MinioFrontendStorage,
       },

--- a/storage/minio/src/test/unit/MinioServerStorageBindings.test.ts
+++ b/storage/minio/src/test/unit/MinioServerStorageBindings.test.ts
@@ -28,22 +28,21 @@ describe(`${MinioServerStorageBindings.name}`, () => {
   describe(`${serverBindings.register.name}()`, () => {
     const bindingsTestCases: DependencyBindingsTestCase[] = [
       {
-        symbolUnderTestName: ServerStorage.name,
-        functionUnderTest: (container: Container) =>
-          container.get(ServerStorage),
+        testedClassIdentifier: ServerStorage.name,
+        testedFunction: (container: Container) => container.get(ServerStorage),
         expectedCtor: MinioServerStorage,
       },
       {
-        symbolUnderTestName: Types.Server.presignedUrlProvider.toString(),
-        functionUnderTest: (container: Container) =>
+        testedClassIdentifier: Types.Server.presignedUrlProvider.toString(),
+        testedFunction: (container: Container) =>
           container.get<PresignedUrlProvider>(
             Types.Server.presignedUrlProvider
           ),
         expectedCtor: MinioPresignedUrlProvider,
       },
       {
-        symbolUnderTestName: Client.name,
-        functionUnderTest: (container: Container) => container.get(Client),
+        testedClassIdentifier: Client.name,
+        testedFunction: (container: Container) => container.get(Client),
         expectedCtor: Client,
       },
     ];

--- a/storage/oss/src/test/unit/OssServerStorageBindings.test.ts
+++ b/storage/oss/src/test/unit/OssServerStorageBindings.test.ts
@@ -23,16 +23,16 @@ describe(`${OssServerStorageBindings.name}`, () => {
   describe(`${serverBindings.register.name}()`, () => {
     const bindingsTestCases: DependencyBindingsTestCase[] = [
       {
-        symbolUnderTestName: Types.Server.transferConfigProvider.toString(),
-        functionUnderTest: (container: Container) =>
+        testedClassIdentifier: Types.Server.transferConfigProvider.toString(),
+        testedFunction: (container: Container) =>
           container.get<TransferConfigProvider>(
             Types.Server.transferConfigProvider
           ),
         expectedCtor: OssTransferConfigProvider,
       },
       {
-        symbolUnderTestName: Core.name,
-        functionUnderTest: (container: Container) => container.get(Core),
+        testedClassIdentifier: Core.name,
+        testedFunction: (container: Container) => container.get(Core),
         expectedCtor: Core,
       },
     ];

--- a/storage/s3/src/test/S3ClientStorageBindings.test.ts
+++ b/storage/s3/src/test/S3ClientStorageBindings.test.ts
@@ -19,17 +19,16 @@ describe(`${S3ClientStorageBindings.name}`, () => {
   describe(`${clientBindings.register.name}()`, () => {
     const bindingsTestCases: DependencyBindingsTestCase[] = [
       {
-        symbolUnderTestName: CoreTypes.Client.clientWrapperFactory.toString(),
-        functionUnderTest: (container: Container) =>
+        testedClassIdentifier: CoreTypes.Client.clientWrapperFactory.toString(),
+        testedFunction: (container: Container) =>
           container.get<S3ClientWrapperFactory>(
             CoreTypes.Client.clientWrapperFactory
           ),
         expectedCtor: S3ClientWrapperFactory,
       },
       {
-        symbolUnderTestName: ClientStorage.name,
-        functionUnderTest: (container: Container) =>
-          container.get(ClientStorage),
+        testedClassIdentifier: ClientStorage.name,
+        testedFunction: (container: Container) => container.get(ClientStorage),
         expectedCtor: S3ClientStorage,
       },
     ];

--- a/storage/s3/src/test/S3FrontendStorageBindings.test.ts
+++ b/storage/s3/src/test/S3FrontendStorageBindings.test.ts
@@ -25,16 +25,17 @@ describe(`${S3FrontendStorageBindings.name}`, () => {
   describe(`${frontendBindings.register.name}()`, () => {
     const bindingsTestCases: DependencyBindingsTestCase[] = [
       {
-        symbolUnderTestName: CoreTypes.Frontend.clientWrapperFactory.toString(),
-        functionUnderTest: (container: Container) =>
+        testedClassIdentifier:
+          CoreTypes.Frontend.clientWrapperFactory.toString(),
+        testedFunction: (container: Container) =>
           container.get<S3ClientWrapperFactory>(
             CoreTypes.Frontend.clientWrapperFactory
           ),
         expectedCtor: S3ClientWrapperFactory,
       },
       {
-        symbolUnderTestName: FrontendStorage.name,
-        functionUnderTest: (container: Container) =>
+        testedClassIdentifier: FrontendStorage.name,
+        testedFunction: (container: Container) =>
           container.get(FrontendStorage),
         expectedCtor: S3FrontendStorage,
       },

--- a/storage/s3/src/test/S3ServerStorageBindings.test.ts
+++ b/storage/s3/src/test/S3ServerStorageBindings.test.ts
@@ -104,50 +104,50 @@ describe(`${S3ServerStorageBindings.name}`, () => {
 
     const bindingsTestCases: DependencyBindingsTestCase[] = [
       {
-        symbolUnderTestName: Types.S3Server.config.toString(),
-        functionUnderTest: (container: Container) =>
+        testedClassIdentifier: Types.S3Server.config.toString(),
+        testedFunction: (container: Container) =>
           container.get<S3ServerStorageConfig>(Types.S3Server.config),
         expectedCtor: Object,
       },
       {
-        symbolUnderTestName: ServerStorage.name,
-        functionUnderTest: (container: Container) =>
-          container.get(ServerStorage),
+        testedClassIdentifier: ServerStorage.name,
+        testedFunction: (container: Container) => container.get(ServerStorage),
         expectedCtor: S3ServerStorage,
       },
       {
-        symbolUnderTestName: S3Client.name,
-        functionUnderTest: (container: Container) => container.get(S3Client),
+        testedClassIdentifier: S3Client.name,
+        testedFunction: (container: Container) => container.get(S3Client),
         expectedCtor: S3Client,
       },
       {
-        symbolUnderTestName: STSClient.name,
-        functionUnderTest: (container: Container) => container.get(STSClient),
+        testedClassIdentifier: STSClient.name,
+        testedFunction: (container: Container) => container.get(STSClient),
         expectedCtor: STSClient,
       },
       {
-        symbolUnderTestName: Types.bucket.toString(),
-        functionUnderTest: (container: Container) =>
+        testedClassIdentifier: Types.bucket.toString(),
+        testedFunction: (container: Container) =>
           container.get<string>(Types.bucket),
         expectedCtor: String,
       },
       {
-        symbolUnderTestName: S3ClientWrapper.name,
-        functionUnderTest: (container: Container) =>
+        testedClassIdentifier: S3ClientWrapper.name,
+        testedFunction: (container: Container) =>
           container.get(S3ClientWrapper),
         expectedCtor: S3ClientWrapper,
       },
       {
-        symbolUnderTestName: CoreTypes.Server.presignedUrlProvider.toString(),
-        functionUnderTest: (container: Container) =>
+        testedClassIdentifier: CoreTypes.Server.presignedUrlProvider.toString(),
+        testedFunction: (container: Container) =>
           container.get<PresignedUrlProvider>(
             CoreTypes.Server.presignedUrlProvider
           ),
         expectedCtor: S3PresignedUrlProvider,
       },
       {
-        symbolUnderTestName: CoreTypes.Server.transferConfigProvider.toString(),
-        functionUnderTest: (container: Container) =>
+        testedClassIdentifier:
+          CoreTypes.Server.transferConfigProvider.toString(),
+        testedFunction: (container: Container) =>
           container.get<TransferConfigProvider>(
             CoreTypes.Server.transferConfigProvider
           ),

--- a/tests/backend-storage/src/test/ClientStorage.test.ts
+++ b/tests/backend-storage/src/test/ClientStorage.test.ts
@@ -83,7 +83,7 @@ describe(`${ClientStorage.name}: ${clientStorage.constructor.name}`, () => {
             contentBuffer
           );
         await testUploadToUrl({
-          storageUnderTest: clientStorage,
+          testedStorage: clientStorage,
           dataToUpload: fileToUploadPath,
           dataToAssert: contentBuffer,
         });
@@ -105,7 +105,7 @@ describe(`${ClientStorage.name}: ${clientStorage.constructor.name}`, () => {
             contentBuffer
           );
         await testUploadToUrlWithRelativeDir({
-          storageUnderTest: clientStorage,
+          testedStorage: clientStorage,
           dataToUpload: fileToUploadPath,
           dataToAssert: contentBuffer,
         });
@@ -127,7 +127,7 @@ describe(`${ClientStorage.name}: ${clientStorage.constructor.name}`, () => {
             contentBuffer
           );
         await testUploadToUrlWithMetadata({
-          storageUnderTest: clientStorage,
+          testedStorage: clientStorage,
           dataToUpload: fileToUploadPath,
           dataToAssert: contentBuffer,
         });
@@ -209,7 +209,7 @@ describe(`${ClientStorage.name}: ${clientStorage.constructor.name}`, () => {
             buffer
           );
         await testUploadWithConfig({
-          storageUnderTest: clientStorage,
+          testedStorage: clientStorage,
           dataToUpload: fileToUploadPath,
           dataToAssert: buffer,
         });
@@ -233,7 +233,7 @@ describe(`${ClientStorage.name}: ${clientStorage.constructor.name}`, () => {
             buffer
           );
         await testUploadWithRelativeDirWithConfig({
-          storageUnderTest: clientStorage,
+          testedStorage: clientStorage,
           dataToUpload: fileToUploadPath,
           dataToAssert: buffer,
         });
@@ -257,7 +257,7 @@ describe(`${ClientStorage.name}: ${clientStorage.constructor.name}`, () => {
             buffer
           );
         await testUploadWithMetadataWithConfig({
-          storageUnderTest: clientStorage,
+          testedStorage: clientStorage,
           dataToUpload: fileToUploadPath,
           dataToAssert: buffer,
         });
@@ -301,7 +301,7 @@ describe(`${ClientStorage.name}: ${clientStorage.constructor.name}`, () => {
             buffer
           );
         await testMultipartUpload({
-          storageUnderTest: clientStorage,
+          testedStorage: clientStorage,
           dataToUpload: fileToUploadPath,
           dataToAssert: buffer,
         });
@@ -321,7 +321,7 @@ describe(`${ClientStorage.name}: ${clientStorage.constructor.name}`, () => {
             buffer
           );
         await testMultipartUploadWithRelativeDir({
-          storageUnderTest: clientStorage,
+          testedStorage: clientStorage,
           dataToUpload: fileToUploadPath,
           dataToAssert: buffer,
         });
@@ -341,7 +341,7 @@ describe(`${ClientStorage.name}: ${clientStorage.constructor.name}`, () => {
             buffer
           );
         await testMultipartUploadWithMetadata({
-          storageUnderTest: clientStorage,
+          testedStorage: clientStorage,
           dataToUpload: fileToUploadPath,
           dataToAssert: buffer,
         });

--- a/tests/backend-storage/src/test/test-templates/DownloadTests.ts
+++ b/tests/backend-storage/src/test/test-templates/DownloadTests.ts
@@ -15,7 +15,7 @@ import { assertBuffer, assertStream, TestRemoteDirectory } from "../utils";
 const { serverStorage } = config;
 
 export async function testDownloadFromUrlToBuffer(
-  storageUnderTest: FrontendStorage | ClientStorage
+  testedStorage: FrontendStorage | ClientStorage
 ): Promise<void> {
   const contentBuffer = Buffer.from("test-download-from-url-to-buffer");
   const testDirectory: TestRemoteDirectory =
@@ -27,7 +27,7 @@ export async function testDownloadFromUrlToBuffer(
   );
 
   const downloadUrl = await serverStorage.getDownloadUrl(uploadedFile);
-  const response = await storageUnderTest.download({
+  const response = await testedStorage.download({
     url: downloadUrl,
     transferType: "buffer",
   });
@@ -36,7 +36,7 @@ export async function testDownloadFromUrlToBuffer(
 }
 
 export async function testDownloadFromUrlToStream(
-  storageUnderTest: FrontendStorage | ClientStorage
+  testedStorage: FrontendStorage | ClientStorage
 ): Promise<void> {
   const contentBuffer = Buffer.from("test-download-from-url-to-stream");
   const testDirectory: TestRemoteDirectory =
@@ -48,7 +48,7 @@ export async function testDownloadFromUrlToStream(
   );
 
   const downloadUrl = await serverStorage.getDownloadUrl(uploadedFile);
-  const response = await storageUnderTest.download({
+  const response = await testedStorage.download({
     url: downloadUrl,
     transferType: "stream",
   });
@@ -57,7 +57,7 @@ export async function testDownloadFromUrlToStream(
 }
 
 export async function testDownloadToBufferWithConfig(
-  storageUnderTest: FrontendStorage | ClientStorage
+  testedStorage: FrontendStorage | ClientStorage
 ): Promise<void> {
   const contentBuffer = Buffer.from("test-download-to-buffer-with-config");
   const testDirectory: TestRemoteDirectory =
@@ -71,7 +71,7 @@ export async function testDownloadToBufferWithConfig(
   const downloadConfig = await serverStorage.getDownloadConfig(
     testDirectory.baseDirectory
   );
-  const response = await storageUnderTest.download({
+  const response = await testedStorage.download({
     reference: uploadedFile,
     transferConfig: downloadConfig,
     transferType: "buffer",
@@ -81,7 +81,7 @@ export async function testDownloadToBufferWithConfig(
 }
 
 export async function testDownloadToStreamWithConfig(
-  storageUnderTest: FrontendStorage | ClientStorage
+  testedStorage: FrontendStorage | ClientStorage
 ): Promise<void> {
   const contentBuffer = Buffer.from("test-download-to-stream-with-config");
   const testDirectory: TestRemoteDirectory =
@@ -95,7 +95,7 @@ export async function testDownloadToStreamWithConfig(
   const downloadConfig = await serverStorage.getDownloadConfig(
     testDirectory.baseDirectory
   );
-  const response = await storageUnderTest.download({
+  const response = await testedStorage.download({
     reference: uploadedFile,
     transferConfig: downloadConfig,
     transferType: "stream",

--- a/tests/backend-storage/src/test/test-templates/UploadTests.ts
+++ b/tests/backend-storage/src/test/test-templates/UploadTests.ts
@@ -33,11 +33,11 @@ interface DataToAssertParam {
 }
 
 interface ClientStorageParam {
-  storageUnderTest: ClientStorage;
+  testedStorage: ClientStorage;
 }
 
 interface FrontendStorageParam {
-  storageUnderTest: FrontendStorage;
+  testedStorage: FrontendStorage;
 }
 
 type ClientTestCase = ClientStorageParam &
@@ -77,75 +77,75 @@ async function getTestStream(data: string): Promise<Readable> {
 }
 
 export async function testUploadFromBufferToUrl(
-  storageUnderTest: FrontendStorage | ClientStorage
+  testedStorage: FrontendStorage | ClientStorage
 ): Promise<void> {
   const buffer = Buffer.from(
-    `${storageUnderTest.constructor.name}-test-upload-from-buffer-to-url`
+    `${testedStorage.constructor.name}-test-upload-from-buffer-to-url`
   );
   return testUploadToUrl({
-    storageUnderTest,
+    testedStorage,
     dataToUpload: buffer,
     dataToAssert: buffer,
   });
 }
 
 export async function testUploadFromStreamToUrl(
-  storageUnderTest: FrontendStorage | ClientStorage
+  testedStorage: FrontendStorage | ClientStorage
 ): Promise<void> {
-  const data = `${storageUnderTest.constructor.name}-test-upload-from-stream-to-url`;
+  const data = `${testedStorage.constructor.name}-test-upload-from-stream-to-url`;
   const stream = await getTestStream(data);
   return testUploadToUrl({
-    storageUnderTest,
+    testedStorage,
     dataToUpload: stream,
     dataToAssert: Buffer.from(data),
   });
 }
 
 export async function testUploadWithRelativeDirFromBufferToUrl(
-  storageUnderTest: FrontendStorage | ClientStorage
+  testedStorage: FrontendStorage | ClientStorage
 ): Promise<void> {
   const buffer = Buffer.from(
-    `${storageUnderTest.constructor.name}-test-upload-from-buffer-to-url-relative-dir`
+    `${testedStorage.constructor.name}-test-upload-from-buffer-to-url-relative-dir`
   );
   return testUploadToUrlWithRelativeDir({
-    storageUnderTest,
+    testedStorage,
     dataToUpload: buffer,
     dataToAssert: buffer,
   });
 }
 
 export async function testUploadWithRelativeDirFromStreamToUrl(
-  storageUnderTest: FrontendStorage | ClientStorage
+  testedStorage: FrontendStorage | ClientStorage
 ): Promise<void> {
-  const data = `${storageUnderTest.constructor.name}-test-upload-from-stream-to-url-relative-dir`;
+  const data = `${testedStorage.constructor.name}-test-upload-from-stream-to-url-relative-dir`;
   const stream = await getTestStream(data);
   return testUploadToUrlWithRelativeDir({
-    storageUnderTest,
+    testedStorage,
     dataToUpload: stream,
     dataToAssert: Buffer.from(data),
   });
 }
 
 export async function testUploadWithMetadataFromBufferToUrl(
-  storageUnderTest: FrontendStorage | ClientStorage
+  testedStorage: FrontendStorage | ClientStorage
 ): Promise<void> {
   const buffer = Buffer.from(
-    `${storageUnderTest.constructor.name}-test-upload-from-buffer-to-url-metadata`
+    `${testedStorage.constructor.name}-test-upload-from-buffer-to-url-metadata`
   );
   return testUploadToUrlWithMetadata({
-    storageUnderTest,
+    testedStorage,
     dataToUpload: buffer,
     dataToAssert: buffer,
   });
 }
 
 export async function testUploadWithMetadataFromStreamToUrl(
-  storageUnderTest: FrontendStorage | ClientStorage
+  testedStorage: FrontendStorage | ClientStorage
 ): Promise<void> {
-  const data = `${storageUnderTest.constructor.name}-test-upload-from-stream-to-url-metadata`;
+  const data = `${testedStorage.constructor.name}-test-upload-from-stream-to-url-metadata`;
   const stream = await getTestStream(data);
   return testUploadToUrlWithMetadata({
-    storageUnderTest,
+    testedStorage,
     dataToUpload: stream,
     dataToAssert: Buffer.from(data),
   });
@@ -205,75 +205,75 @@ export async function testUploadToUrlWithMetadata(
 }
 
 export async function testUploadFromBufferWithConfig(
-  storageUnderTest: FrontendStorage | ClientStorage
+  testedStorage: FrontendStorage | ClientStorage
 ): Promise<void> {
   const buffer = Buffer.from(
-    `${storageUnderTest.constructor.name}-test-upload-from-buffer-with-config`
+    `${testedStorage.constructor.name}-test-upload-from-buffer-with-config`
   );
   return testUploadWithConfig({
-    storageUnderTest,
+    testedStorage,
     dataToUpload: buffer,
     dataToAssert: buffer,
   });
 }
 
 export async function testUploadFromStreamWithConfig(
-  storageUnderTest: FrontendStorage | ClientStorage
+  testedStorage: FrontendStorage | ClientStorage
 ): Promise<void> {
-  const data = `${storageUnderTest.constructor.name}-test-upload-from-stream-with-config`;
+  const data = `${testedStorage.constructor.name}-test-upload-from-stream-with-config`;
   const stream = await getTestStream(data);
   return testUploadWithConfig({
-    storageUnderTest,
+    testedStorage,
     dataToUpload: stream,
     dataToAssert: Buffer.from(data),
   });
 }
 
 export async function testUploadWithRelativeDirFromBufferWithConfig(
-  storageUnderTest: FrontendStorage | ClientStorage
+  testedStorage: FrontendStorage | ClientStorage
 ): Promise<void> {
   const buffer = Buffer.from(
-    `${storageUnderTest.constructor.name}-test-upload-with-relative-dir-from-buffer-with-config`
+    `${testedStorage.constructor.name}-test-upload-with-relative-dir-from-buffer-with-config`
   );
   return testUploadWithRelativeDirWithConfig({
-    storageUnderTest,
+    testedStorage,
     dataToUpload: buffer,
     dataToAssert: buffer,
   });
 }
 
 export async function testUploadWithRelativeDirFromStreamWithConfig(
-  storageUnderTest: FrontendStorage | ClientStorage
+  testedStorage: FrontendStorage | ClientStorage
 ): Promise<void> {
-  const data = `${storageUnderTest.constructor.name}-test-upload-with-relative-dir-from-stream-with-config`;
+  const data = `${testedStorage.constructor.name}-test-upload-with-relative-dir-from-stream-with-config`;
   const stream = await getTestStream(data);
   return testUploadWithRelativeDirWithConfig({
-    storageUnderTest,
+    testedStorage,
     dataToUpload: stream,
     dataToAssert: Buffer.from(data),
   });
 }
 
 export async function testUploadWithMetadataFromBufferWithConfig(
-  storageUnderTest: FrontendStorage | ClientStorage
+  testedStorage: FrontendStorage | ClientStorage
 ): Promise<void> {
   const buffer = Buffer.from(
-    `${storageUnderTest.constructor.name}-test-upload-with-metadata-from-buffer-with-config`
+    `${testedStorage.constructor.name}-test-upload-with-metadata-from-buffer-with-config`
   );
   return testUploadWithMetadataWithConfig({
-    storageUnderTest,
+    testedStorage,
     dataToUpload: buffer,
     dataToAssert: buffer,
   });
 }
 
 export async function testUploadWithMetadataFromStreamWithConfig(
-  storageUnderTest: FrontendStorage | ClientStorage
+  testedStorage: FrontendStorage | ClientStorage
 ): Promise<void> {
-  const data = `${storageUnderTest.constructor.name}-test-upload-with-metadata-from-stream-with-config`;
+  const data = `${testedStorage.constructor.name}-test-upload-with-metadata-from-stream-with-config`;
   const stream = await getTestStream(data);
   return testUploadWithMetadataWithConfig({
-    storageUnderTest,
+    testedStorage,
     dataToUpload: stream,
     dataToAssert: Buffer.from(data),
   });
@@ -340,36 +340,36 @@ export async function testUploadWithMetadataWithConfig(
 }
 
 export async function testMultipartUploadFromStream(
-  storageUnderTest: FrontendStorage | ClientStorage
+  testedStorage: FrontendStorage | ClientStorage
 ): Promise<void> {
-  const data = `${storageUnderTest.constructor.name}-test-upload-with-relative-dir-from-stream-with-config`;
+  const data = `${testedStorage.constructor.name}-test-upload-with-relative-dir-from-stream-with-config`;
   const stream = await getTestStream(data);
   return testMultipartUpload({
-    storageUnderTest,
+    testedStorage,
     dataToUpload: stream,
     dataToAssert: Buffer.from(data),
   });
 }
 
 export async function testMultipartUploadWithRelativeDirFromStream(
-  storageUnderTest: FrontendStorage | ClientStorage
+  testedStorage: FrontendStorage | ClientStorage
 ): Promise<void> {
-  const data = `${storageUnderTest.constructor.name}-test-upload-with-relative-dir-from-stream-with-config`;
+  const data = `${testedStorage.constructor.name}-test-upload-with-relative-dir-from-stream-with-config`;
   const stream = await getTestStream(data);
   return testMultipartUploadWithRelativeDir({
-    storageUnderTest,
+    testedStorage,
     dataToUpload: stream,
     dataToAssert: Buffer.from(data),
   });
 }
 
 export async function testMultipartUploadWithMetadataFromStream(
-  storageUnderTest: FrontendStorage | ClientStorage
+  testedStorage: FrontendStorage | ClientStorage
 ): Promise<void> {
-  const data = `${storageUnderTest.constructor.name}-test-upload-with-relative-dir-from-stream-with-config`;
+  const data = `${testedStorage.constructor.name}-test-upload-with-relative-dir-from-stream-with-config`;
   const stream = await getTestStream(data);
   return testMultipartUploadWithMetadata({
-    storageUnderTest,
+    testedStorage,
     dataToUpload: stream,
     dataToAssert: Buffer.from(data),
   });
@@ -440,13 +440,13 @@ export async function testMultipartUploadWithMetadata(
 function isClientTestCase(
   testCase: TestCase | MultipartTestCase
 ): testCase is ClientTestCase | MultipartClientTestCase {
-  return testCase.storageUnderTest instanceof ClientStorage;
+  return testCase.testedStorage instanceof ClientStorage;
 }
 
 function isFrontendTestCase(
   testCase: TestCase | MultipartTestCase
 ): testCase is FrontendTestCase | MultipartFrontendTestCase {
-  return testCase.storageUnderTest instanceof FrontendStorage;
+  return testCase.testedStorage instanceof FrontendStorage;
 }
 
 async function callUrlUpload(
@@ -455,13 +455,13 @@ async function callUrlUpload(
   metadata: Metadata | undefined
 ): Promise<void> {
   if (isClientTestCase(params)) {
-    return params.storageUnderTest.upload({
+    return params.testedStorage.upload({
       data: params.dataToUpload,
       url,
       metadata,
     });
   } else if (isFrontendTestCase(params)) {
-    return params.storageUnderTest.upload({
+    return params.testedStorage.upload({
       data: params.dataToUpload,
       url,
       metadata,
@@ -478,14 +478,14 @@ async function callConfigUpload(
   metadata: Metadata | undefined
 ): Promise<void> {
   if (isClientTestCase(params)) {
-    return params.storageUnderTest.upload({
+    return params.testedStorage.upload({
       data: params.dataToUpload,
       reference,
       transferConfig,
       metadata,
     });
   } else if (isFrontendTestCase(params)) {
-    return params.storageUnderTest.upload({
+    return params.testedStorage.upload({
       data: params.dataToUpload,
       reference,
       transferConfig,
@@ -503,14 +503,14 @@ async function callUploadInMultipleParts(
   metadata: Metadata | undefined
 ): Promise<void> {
   if (isClientTestCase(params)) {
-    return params.storageUnderTest.uploadInMultipleParts({
+    return params.testedStorage.uploadInMultipleParts({
       data: params.dataToUpload,
       reference,
       transferConfig,
       options: { metadata },
     });
   } else if (isFrontendTestCase(params)) {
-    return params.storageUnderTest.uploadInMultipleParts({
+    return params.testedStorage.uploadInMultipleParts({
       data: params.dataToUpload,
       reference,
       transferConfig,

--- a/tests/unit/src/CommonTests.ts
+++ b/tests/unit/src/CommonTests.ts
@@ -10,8 +10,8 @@ import { Dependency, DependencyConfig } from "@itwin/cloud-agnostic-core";
 import { ServerStorageDependency } from "@itwin/object-storage-core";
 
 export interface DependencyBindingsTestCase {
-  symbolUnderTestName: string;
-  functionUnderTest: (container: Container) => unknown;
+  testedClassIdentifier: string;
+  testedFunction: (container: Container) => unknown;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   expectedCtor: new (...args: any[]) => unknown;
 }
@@ -27,27 +27,27 @@ export function testBindings(
   testCases: DependencyBindingsTestCase[]
 ): void {
   for (const testCase of testCases) {
-    it(`should register ${testCase.symbolUnderTestName}`, () => {
+    it(`should register ${testCase.testedClassIdentifier}`, () => {
       const container = new Container();
       bindings.register(container, config);
 
-      const functionUnderTest = () => testCase.functionUnderTest(container);
-      expect(functionUnderTest).to.not.throw();
+      const testedFunction = () => testCase.testedFunction(container);
+      expect(testedFunction).to.not.throw();
     });
 
-    it(`should register ${testCase.symbolUnderTestName} as a singleton`, () => {
+    it(`should register ${testCase.testedClassIdentifier} as a singleton`, () => {
       const container = new Container();
       bindings.register(container, config);
-      const instance1 = testCase.functionUnderTest(container);
-      const instance2 = testCase.functionUnderTest(container);
+      const instance1 = testCase.testedFunction(container);
+      const instance2 = testCase.testedFunction(container);
 
       expect(instance1).to.be.equal(instance2);
     });
 
-    it(`should resolve ${testCase.symbolUnderTestName} to ${testCase.expectedCtor.name}`, () => {
+    it(`should resolve ${testCase.testedClassIdentifier} to ${testCase.expectedCtor.name}`, () => {
       const container = new Container();
       bindings.register(container, config);
-      const instance = testCase.functionUnderTest(container);
+      const instance = testCase.testedFunction(container);
 
       expect(Object.getPrototypeOf(instance).constructor.name).to.be.equal(
         testCase.expectedCtor.name
@@ -64,9 +64,9 @@ export function testInvalidServerConfig(
     it(`should throw if dependency config is invalid (${testCase.expectedErrorMessage})`, () => {
       const container = new Container();
 
-      const functionUnderTest = () =>
+      const testedFunction = () =>
         serverBindings.register(container, testCase.config);
-      expect(functionUnderTest)
+      expect(testedFunction)
         .to.throw(Error)
         .with.property("message", testCase.expectedErrorMessage);
     });


### PR DESCRIPTION
In this PR:
- Renamed variables and property named that included `underTest`:
  - `storageUnderTest` -> `testedStorage`
  - `symbolUnderTestName` -> `testedClassIdentifier`
  - `functionUnderTest` -> `testedFunction`