### PR TITLE
Publish pipeline fix

### DIFF
--- a/common/config/azure-pipelines/templates/publish.yml
+++ b/common/config/azure-pipelines/templates/publish.yml
@@ -1,4 +1,16 @@
 steps:
+  - task: NodeTool@0
+    displayName: Install Node@14.17.5
+    inputs:
+      versionSpec: '14.17.5'
+      checkLatest: true
+
+  - script: node common/scripts/install-run-rush.js install --purge
+    displayName: rush install
+
+  - script: node common/scripts/install-run-rush.js rebuild -v
+    displayName: rush rebuild
+
   - script: node common/scripts/install-run-rush.js publish --publish --include-all --set-access-level public
     displayName: rush publish package
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))


### PR DESCRIPTION
In this PR:
- Fixed the publish pipeline: as the new publish job it now requires the same setup as the build and test jobs: Node install, package install and code build.