### PR TITLE
Updating TS version, ensuring packages work with node 12 and 16

### DIFF
--- a/cloud-agnostic/core/package.json
+++ b/cloud-agnostic/core/package.json
@@ -50,7 +50,7 @@
     "nyc": "^14.0.0",
     "rimraf": "^2.6.2",
     "sort-package-json": "~1.53.1",
-    "typescript": "~4.3.0"
+    "typescript": "~4.7.4"
   },
   "engines": {
     "node": ">=12.20 <17.0.0"

--- a/cloud-agnostic/core/src/Errors.ts
+++ b/cloud-agnostic/core/src/Errors.ts
@@ -19,7 +19,7 @@ export class DependencyError extends Error {
 }
 
 export class ConfigError<T> extends Error {
-  constructor(property: keyof T) {
+  constructor(property: keyof T & string) {
     super(`${property} is not defined in configuration`);
   }
 }

--- a/common/config/azure-pipelines/build-test-publish.yml
+++ b/common/config/azure-pipelines/build-test-publish.yml
@@ -7,7 +7,7 @@ parameters:
   default: true
 
 variables:
-  node16Version: '16.13.2'
+  node16Version: '16.15.0'
   node12Version: '12.17.0'
 
 trigger: none

--- a/common/config/azure-pipelines/build-test-publish.yml
+++ b/common/config/azure-pipelines/build-test-publish.yml
@@ -6,16 +6,32 @@ parameters:
   type: boolean
   default: true
 
+variables:
+  node16Version: '16.13.2'
+  node12Version: '12.17.0'
+
 trigger: none
 
 jobs:
   - job: BuildAndTest
     strategy:
       matrix:
-        linux:
+        linux-node-16:
           imageName: 'ubuntu-latest'
-        windows:
+          nodeVersion: $(node16Version)
+          runFrontendIntegrationTests: true
+        windows-node-16:
           imageName: 'windows-latest'
+          nodeVersion: $(node16Version)
+          runFrontendIntegrationTests: true
+        linux-node-12:
+          imageName: 'ubuntu-latest'
+          nodeVersion: $(node12Version)
+          runFrontendIntegrationTests: false
+        windows-node-12:
+          imageName: 'windows-latest'
+          nodeVersion: $(node12Version)
+          runFrontendIntegrationTests: false
     pool:
         vmImage: $(imageName)
     variables:

--- a/common/config/azure-pipelines/build-test.yml
+++ b/common/config/azure-pipelines/build-test.yml
@@ -7,7 +7,7 @@ parameters:
   default: true
 
 variables:
-  node16Version: '16.13.2'
+  node16Version: '16.15.0'
   node12Version: '12.17.0'
 
 trigger: none

--- a/common/config/azure-pipelines/build-test.yml
+++ b/common/config/azure-pipelines/build-test.yml
@@ -6,16 +6,24 @@ parameters:
   type: boolean
   default: true
 
+variables:
+  node16Version: '16.13.2'
+  node12Version: '12.17.0'
+
 trigger: none
 
 jobs:
   - job: BuildAndTest
     strategy:
       matrix:
-        linux:
+        linux-node-16:
           imageName: 'ubuntu-latest'
-        windows:
+          nodeVersion: $(node16Version)
+          runFrontendIntegrationTests: true
+        windows-node-16:
           imageName: 'windows-latest'
+          nodeVersion: $(node16Version)
+          runFrontendIntegrationTests: true
     pool:
         vmImage: $(imageName)
     variables:

--- a/common/config/azure-pipelines/templates/build-test.yml
+++ b/common/config/azure-pipelines/templates/build-test.yml
@@ -5,9 +5,9 @@ parameters:
 
 steps:
   - task: NodeTool@0
-    displayName: Install Node@14.17.5
+    displayName: Install Node@$(nodeVersion)
     inputs:
-      versionSpec: '14.17.5'
+      versionSpec: $(nodeVersion)
       checkLatest: true
 
   - script: node common/scripts/install-run-rush.js install --purge
@@ -39,6 +39,7 @@ steps:
 
   - script: node common/scripts/install-run-rush.js test:integration:frontend --verbose
     displayName: rush test:integration:frontend
+    condition: and(succeeded(), eq(variables.runFrontendIntegrationTests, true))
     env:
       TEST_AZURE_STORAGE_ACCOUNT_KEY: $(TEST_AZURE_STORAGE_ACCOUNT_KEY)
       TEST_OSS_ACCESS_KEY: $(TEST_OSS_ACCESS_KEY)

--- a/common/config/azure-pipelines/templates/publish.yml
+++ b/common/config/azure-pipelines/templates/publish.yml
@@ -1,8 +1,8 @@
 steps:
   - task: NodeTool@0
-    displayName: Install Node@14.17.5
+    displayName: Install Node@$(node16Version)
     inputs:
-      versionSpec: '14.17.5'
+      versionSpec: $(node16Version)
       checkLatest: true
 
   - script: node common/scripts/install-run-rush.js install --purge

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
       reflect-metadata: ~0.1.13
       rimraf: ^2.6.2
       sort-package-json: ~1.53.1
-      typescript: ~4.3.0
+      typescript: ~4.7.4
     dependencies:
       inversify: 5.0.5
       reflect-metadata: 0.1.13
@@ -36,7 +36,7 @@ importers:
       nyc: 14.1.1
       rimraf: 2.7.1
       sort-package-json: 1.53.1
-      typescript: 4.3.5
+      typescript: 4.7.4
 
   ../../samples:
     specifiers:
@@ -44,14 +44,14 @@ importers:
       '@itwin/object-storage-azure': workspace:*
       '@itwin/object-storage-common-config': workspace:*
       '@itwin/object-storage-core': workspace:*
-      '@types/node': ^14.14.41
+      '@types/node': ~16.6.2
       cspell: ~5.18.5
       eslint: ~7.32.0
       inversify: ~5.0.1
       reflect-metadata: ~0.1.13
       rimraf: ^2.6.2
       sort-package-json: ~1.53.1
-      typescript: ~4.3.0
+      typescript: ~4.7.4
     dependencies:
       '@itwin/cloud-agnostic-core': link:../cloud-agnostic/core
       '@itwin/object-storage-azure': link:../storage/azure
@@ -60,12 +60,12 @@ importers:
       reflect-metadata: 0.1.13
     devDependencies:
       '@itwin/object-storage-common-config': link:../utils/common-config
-      '@types/node': 14.18.12
+      '@types/node': 16.6.2
       cspell: 5.18.5
       eslint: 7.32.0
       rimraf: 2.7.1
       sort-package-json: 1.53.1
-      typescript: 4.3.5
+      typescript: 4.7.4
 
   ../../storage/azure:
     specifiers:
@@ -79,7 +79,7 @@ importers:
       '@types/chai': ^4.1.7
       '@types/chai-as-promised': ^7.1.2
       '@types/mocha': ^8.2.2
-      '@types/node': ^14.14.41
+      '@types/node': ~16.6.2
       '@types/sinon': ~10.0.11
       chai: ^4.2.0
       chai-as-promised: ^7.1.1
@@ -95,7 +95,7 @@ importers:
       rimraf: ^2.6.2
       sinon: ~14.0.0
       sort-package-json: ~1.53.1
-      typescript: ~4.3.0
+      typescript: ~4.7.4
       wait-on: ~6.0.1
       webpack: ~5.72.0
       webpack-cli: ~4.9.2
@@ -113,7 +113,7 @@ importers:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 8.2.3
-      '@types/node': 14.18.12
+      '@types/node': 16.6.2
       '@types/sinon': 10.0.11
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
@@ -127,7 +127,7 @@ importers:
       rimraf: 2.7.1
       sinon: 14.0.0
       sort-package-json: 1.53.1
-      typescript: 4.3.5
+      typescript: 4.7.4
       wait-on: 6.0.1
       webpack: 5.72.0_webpack-cli@4.9.2
       webpack-cli: 4.9.2_webpack@5.72.0
@@ -139,8 +139,8 @@ importers:
       '@types/chai': ^4.1.7
       '@types/chai-as-promised': ^7.1.2
       '@types/mocha': ^8.2.2
-      '@types/node': ^14.14.41
-      axios: ~0.24.0
+      '@types/node': ~16.6.2
+      axios: ~0.27.2
       chai: ^4.2.0
       chai-as-promised: ^7.1.1
       cspell: ~5.18.5
@@ -152,10 +152,10 @@ importers:
       reflect-metadata: ~0.1.13
       rimraf: ^2.6.2
       sort-package-json: ~1.53.1
-      typescript: ~4.3.0
+      typescript: ~4.7.4
     dependencies:
       '@itwin/cloud-agnostic-core': link:../../cloud-agnostic/core
-      axios: 0.24.0
+      axios: 0.27.2
       inversify: 5.0.5
       reflect-metadata: 0.1.13
     devDependencies:
@@ -163,7 +163,7 @@ importers:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 8.2.3
-      '@types/node': 14.18.12
+      '@types/node': 16.6.2
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
       cspell: 5.18.5
@@ -173,7 +173,7 @@ importers:
       nyc: 14.1.1
       rimraf: 2.7.1
       sort-package-json: 1.53.1
-      typescript: 4.3.5
+      typescript: 4.7.4
 
   ../../storage/minio:
     specifiers:
@@ -189,7 +189,7 @@ importers:
       '@types/chai-as-promised': ^7.1.2
       '@types/minio': ~7.0.11
       '@types/mocha': ^8.2.2
-      '@types/node': ^14.14.41
+      '@types/node': ~16.6.2
       '@types/sinon': ~10.0.11
       chai: ^4.2.0
       chai-as-promised: ^7.1.1
@@ -205,7 +205,7 @@ importers:
       rimraf: ^2.6.2
       sinon: ~14.0.0
       sort-package-json: ~1.53.1
-      typescript: ~4.3.0
+      typescript: ~4.7.4
       wait-on: ~6.0.1
       webpack: ~5.72.0
       webpack-cli: ~4.9.2
@@ -226,7 +226,7 @@ importers:
       '@types/chai-as-promised': 7.1.5
       '@types/minio': 7.0.12
       '@types/mocha': 8.2.3
-      '@types/node': 14.18.12
+      '@types/node': 16.6.2
       '@types/sinon': 10.0.11
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
@@ -239,7 +239,7 @@ importers:
       rimraf: 2.7.1
       sinon: 14.0.0
       sort-package-json: 1.53.1
-      typescript: 4.3.5
+      typescript: 4.7.4
       wait-on: 6.0.1
       webpack: 5.72.0_webpack-cli@4.9.2
       webpack-cli: 4.9.2_webpack@5.72.0
@@ -258,7 +258,7 @@ importers:
       '@types/chai': ^4.1.7
       '@types/chai-as-promised': ^7.1.2
       '@types/mocha': ^8.2.2
-      '@types/node': ^14.14.41
+      '@types/node': ~16.6.2
       chai: ^4.2.0
       chai-as-promised: ^7.1.1
       cspell: ~5.18.5
@@ -271,7 +271,7 @@ importers:
       reflect-metadata: ~0.1.13
       rimraf: ^2.6.2
       sort-package-json: ~1.53.1
-      typescript: ~4.3.0
+      typescript: ~4.7.4
       wait-on: ~6.0.1
       webpack: ~5.72.0
       webpack-cli: ~4.9.2
@@ -291,7 +291,7 @@ importers:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 8.2.3
-      '@types/node': 14.18.12
+      '@types/node': 16.6.2
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
       cspell: 5.18.5
@@ -302,7 +302,7 @@ importers:
       nyc: 14.1.1
       rimraf: 2.7.1
       sort-package-json: 1.53.1
-      typescript: 4.3.5
+      typescript: 4.7.4
       wait-on: 6.0.1
       webpack: 5.72.0_webpack-cli@4.9.2
       webpack-cli: 4.9.2_webpack@5.72.0
@@ -320,7 +320,7 @@ importers:
       '@types/chai': ^4.1.7
       '@types/chai-as-promised': ^7.1.2
       '@types/mocha': ^8.2.2
-      '@types/node': ^14.14.41
+      '@types/node': ~16.6.2
       '@types/sinon': ~10.0.11
       chai: ^4.2.0
       chai-as-promised: ^7.1.1
@@ -334,7 +334,7 @@ importers:
       rimraf: ^2.6.2
       sinon: ~14.0.0
       sort-package-json: ~1.53.1
-      typescript: ~4.3.0
+      typescript: ~4.7.4
     dependencies:
       '@aws-sdk/client-s3': 3.105.0
       '@aws-sdk/client-sts': 3.105.0
@@ -350,7 +350,7 @@ importers:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 8.2.3
-      '@types/node': 14.18.12
+      '@types/node': 16.6.2
       '@types/sinon': 10.0.11
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
@@ -362,7 +362,7 @@ importers:
       rimraf: 2.7.1
       sinon: 14.0.0
       sort-package-json: 1.53.1
-      typescript: 4.3.5
+      typescript: 4.7.4
 
   ../../tests/backend-storage:
     specifiers:
@@ -371,24 +371,27 @@ importers:
       '@itwin/object-storage-core': workspace:*
       '@types/chai': ^4.1.7
       '@types/chai-as-promised': ^7.1.2
+      '@types/fs-extra': ~9.0.13
       '@types/mocha': ^8.2.2
-      '@types/node': ^14.14.41
+      '@types/node': ~16.6.2
       '@types/yargs': ~15.0.5
       chai: ^4.2.0
       chai-as-promised: ^7.1.1
       cspell: ~5.18.5
       eslint: ~7.32.0
+      fs-extra: ~10.1.0
       inversify: ~5.0.1
       mocha: ^9.2.1
       reflect-metadata: ~0.1.13
       rimraf: ^2.6.2
       sort-package-json: ~1.53.1
-      typescript: ~4.3.0
+      typescript: ~4.7.4
     dependencies:
       '@itwin/cloud-agnostic-core': link:../../cloud-agnostic/core
       '@itwin/object-storage-core': link:../../storage/core
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
+      fs-extra: 10.1.0
       inversify: 5.0.5
       mocha: 9.2.1
       reflect-metadata: 0.1.13
@@ -396,14 +399,15 @@ importers:
       '@itwin/object-storage-common-config': link:../../utils/common-config
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
+      '@types/fs-extra': 9.0.13
       '@types/mocha': 8.2.3
-      '@types/node': 14.18.12
+      '@types/node': 16.6.2
       '@types/yargs': 15.0.14
       cspell: 5.18.5
       eslint: 7.32.0
       rimraf: 2.7.1
       sort-package-json: 1.53.1
-      typescript: 4.3.5
+      typescript: 4.7.4
 
   ../../tests/backend-storage-unit:
     specifiers:
@@ -413,7 +417,7 @@ importers:
       '@types/chai': ^4.1.7
       '@types/chai-as-promised': ^7.1.2
       '@types/mocha': ^8.2.2
-      '@types/node': ^14.14.41
+      '@types/node': ~16.6.2
       chai: ^4.2.0
       chai-as-promised: ^7.1.1
       cspell: ~5.18.5
@@ -422,7 +426,7 @@ importers:
       mocha: ^9.2.1
       rimraf: ^2.6.2
       sort-package-json: ~1.53.1
-      typescript: ~4.3.0
+      typescript: ~4.7.4
     dependencies:
       '@itwin/cloud-agnostic-core': link:../../cloud-agnostic/core
       '@itwin/object-storage-core': link:../../storage/core
@@ -435,12 +439,12 @@ importers:
       '@types/chai': 4.3.0
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 8.2.3
-      '@types/node': 14.18.12
+      '@types/node': 16.6.2
       cspell: 5.18.5
       eslint: 7.32.0
       rimraf: 2.7.1
       sort-package-json: 1.53.1
-      typescript: 4.3.5
+      typescript: 4.7.4
 
   ../../tests/frontend-storage:
     specifiers:
@@ -448,8 +452,8 @@ importers:
       '@itwin/object-storage-common-config': workspace:*
       '@itwin/object-storage-core': workspace:*
       '@types/express': ~4.17.13
-      '@types/node': ^14.14.41
-      axios: ~0.24.0
+      '@types/node': ~16.6.2
+      axios: ~0.27.2
       cross-env: ~7.0.3
       cspell: ~5.18.5
       cypress: ~9.5.4
@@ -458,7 +462,7 @@ importers:
       inversify: ~5.0.1
       rimraf: ^2.6.2
       sort-package-json: ~1.53.1
-      typescript: ~4.3.0
+      typescript: ~4.7.4
     dependencies:
       '@itwin/cloud-agnostic-core': link:../../cloud-agnostic/core
       '@itwin/object-storage-core': link:../../storage/core
@@ -467,15 +471,15 @@ importers:
     devDependencies:
       '@itwin/object-storage-common-config': link:../../utils/common-config
       '@types/express': 4.17.13
-      '@types/node': 14.18.12
-      axios: 0.24.0
+      '@types/node': 16.6.2
+      axios: 0.27.2
       cross-env: 7.0.3
       cspell: 5.18.5
       eslint: 7.32.0
       express: 4.18.0
       rimraf: 2.7.1
       sort-package-json: 1.53.1
-      typescript: 4.3.5
+      typescript: 4.7.4
 
   ../../utils/common-config:
     specifiers:
@@ -2078,7 +2082,7 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 14.18.12
+      '@types/node': 16.6.2
     dev: true
 
   /@types/chai-as-promised/7.1.5:
@@ -2094,7 +2098,7 @@ packages:
   /@types/connect/3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 14.18.12
+      '@types/node': 16.6.2
     dev: true
 
   /@types/eslint-scope/3.7.3:
@@ -2118,7 +2122,7 @@ packages:
   /@types/express-serve-static-core/4.17.28:
     resolution: {integrity: sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==}
     dependencies:
-      '@types/node': 14.18.12
+      '@types/node': 16.6.2
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
     dev: true
@@ -2132,11 +2136,17 @@ packages:
       '@types/serve-static': 1.13.10
     dev: true
 
+  /@types/fs-extra/9.0.13:
+    resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
+    dependencies:
+      '@types/node': 16.6.2
+    dev: true
+
   /@types/glob/7.2.0:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 14.18.12
+      '@types/node': 16.6.2
     dev: true
 
   /@types/json-schema/7.0.9:
@@ -2158,7 +2168,7 @@ packages:
   /@types/minio/7.0.12:
     resolution: {integrity: sha512-O9hfc+61y8PYSP/6InHNML0VIo9c1UYptgkveHhlLMs2kPjOms3EfSjU2dfnOXIyADvp3v1FRTwRpL9owKdxtw==}
     dependencies:
-      '@types/node': 14.18.12
+      '@types/node': 16.6.2
     dev: true
 
   /@types/mocha/8.2.3:
@@ -2168,12 +2178,15 @@ packages:
   /@types/node-fetch/2.6.1:
     resolution: {integrity: sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==}
     dependencies:
-      '@types/node': 14.18.12
+      '@types/node': 16.6.2
       form-data: 3.0.1
     dev: false
 
   /@types/node/14.18.12:
     resolution: {integrity: sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==}
+
+  /@types/node/16.6.2:
+    resolution: {integrity: sha512-LSw8TZt12ZudbpHc6EkIyDM3nHVWKYrAvGy6EAJfNfjusbwnThqjqxUKKRwuV3iWYeW/LYMzNgaq3MaLffQ2xA==}
 
   /@types/parse-json/4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
@@ -2191,7 +2204,7 @@ packages:
     resolution: {integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 14.18.12
+      '@types/node': 16.6.2
     dev: true
 
   /@types/sinon/10.0.11:
@@ -2209,7 +2222,7 @@ packages:
   /@types/tunnel/0.0.1:
     resolution: {integrity: sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==}
     dependencies:
-      '@types/node': 14.18.12
+      '@types/node': 16.6.2
     dev: false
 
   /@types/yargs-parser/20.2.1:
@@ -2225,7 +2238,7 @@ packages:
   /@types/yauzl/2.10.0:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     dependencies:
-      '@types/node': 14.18.12
+      '@types/node': 16.6.2
     optional: true
 
   /@typescript-eslint/eslint-plugin/4.11.1_20bcd34ae303e6ccd246f34a61afe63c:
@@ -2850,7 +2863,7 @@ packages:
     resolution: {integrity: sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==}
 
   /asynckit/0.4.0:
-    resolution: {integrity: sha1-x57Zf380y48robyXkLzDZkdLS3k=}
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   /at-least-node/1.0.0:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
@@ -2872,13 +2885,6 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /axios/0.24.0:
-    resolution: {integrity: sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==}
-    dependencies:
-      follow-redirects: 1.14.9
-    transitivePeerDependencies:
-      - debug
-
   /axios/0.25.0:
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
     dependencies:
@@ -2886,6 +2892,14 @@ packages:
     transitivePeerDependencies:
       - debug
     dev: true
+
+  /axios/0.27.2:
+    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
+    dependencies:
+      follow-redirects: 1.14.9
+      form-data: 4.0.0
+    transitivePeerDependencies:
+      - debug
 
   /axobject-query/2.2.0:
     resolution: {integrity: sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==}
@@ -3498,7 +3512,7 @@ packages:
       cspell-trie-lib: 5.18.5
       fast-equals: 3.0.0
       find-up: 5.0.0
-      fs-extra: 10.0.0
+      fs-extra: 10.1.0
       gensequence: 3.1.1
       import-fresh: 3.3.0
       resolve-from: 5.0.0
@@ -3511,7 +3525,7 @@ packages:
     engines: {node: '>=12.13.0'}
     dependencies:
       '@cspell/cspell-pipe': 5.18.5
-      fs-extra: 10.0.0
+      fs-extra: 10.1.0
       gensequence: 3.1.1
     dev: true
 
@@ -3529,7 +3543,7 @@ packages:
       cspell-lib: 5.18.5
       fast-json-stable-stringify: 2.1.0
       file-entry-cache: 6.0.1
-      fs-extra: 10.0.0
+      fs-extra: 10.1.0
       get-stdin: 8.0.0
       glob: 7.2.0
       imurmurhash: 0.1.4
@@ -3667,7 +3681,7 @@ packages:
       object-keys: 1.1.1
 
   /delayed-stream/1.0.0:
-    resolution: {integrity: sha1-3zrhmayt+31ECqrgsp4icrJOxhk=}
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
   /depd/2.0.0:
@@ -4523,6 +4537,14 @@ packages:
       mime-types: 2.1.34
     dev: false
 
+  /form-data/4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.34
+
   /forwarded/0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -4533,14 +4555,13 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
-  /fs-extra/10.0.0:
-    resolution: {integrity: sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==}
+  /fs-extra/10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
     dependencies:
       graceful-fs: 4.2.9
       jsonfile: 6.1.0
       universalify: 2.0.0
-    dev: true
 
   /fs-extra/9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
@@ -5156,7 +5177,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 14.18.12
+      '@types/node': 16.6.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -7023,8 +7044,8 @@ packages:
       is-typedarray: 1.0.0
     dev: true
 
-  /typescript/4.3.5:
-    resolution: {integrity: sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==}
+  /typescript/4.7.4:
+    resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true

--- a/rush.json
+++ b/rush.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
-  "rushVersion": "5.68.1",
+  "rushVersion": "5.75.0",
   "pnpmVersion": "6.13.0",
   "nodeSupportedVersionRange": ">=12.17.0 <17.0.0",
   "ensureConsistentVersions": true,

--- a/rush.json
+++ b/rush.json
@@ -2,7 +2,7 @@
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
   "rushVersion": "5.68.1",
   "pnpmVersion": "6.13.0",
-  "nodeSupportedVersionRange": ">=10.17.0 <15.0.0",
+  "nodeSupportedVersionRange": ">=12.17.0 <17.0.0",
   "ensureConsistentVersions": true,
   "projectFolderMinDepth": 1,
   "projectFolderMaxDepth": 2,

--- a/samples/package.json
+++ b/samples/package.json
@@ -35,12 +35,12 @@
   },
   "devDependencies": {
     "@itwin/object-storage-common-config": "workspace:*",
-    "@types/node": "^14.14.41",
+    "@types/node": "~16.6.2",
     "cspell": "~5.18.5",
     "eslint": "~7.32.0",
     "rimraf": "^2.6.2",
     "sort-package-json": "~1.53.1",
-    "typescript": "~4.3.0"
+    "typescript": "~4.7.4"
   },
   "engines": {
     "node": ">=12.20 <17.0.0"

--- a/storage/azure/package.json
+++ b/storage/azure/package.json
@@ -52,7 +52,7 @@
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.2",
     "@types/mocha": "^8.2.2",
-    "@types/node": "^14.14.41",
+    "@types/node": "~16.6.2",
     "@types/sinon": "~10.0.11",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
@@ -66,7 +66,7 @@
     "rimraf": "^2.6.2",
     "sinon": "~14.0.0",
     "sort-package-json": "~1.53.1",
-    "typescript": "~4.3.0",
+    "typescript": "~4.7.4",
     "wait-on": "~6.0.1",
     "webpack": "~5.72.0",
     "webpack-cli": "~4.9.2"

--- a/storage/core/package.json
+++ b/storage/core/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@itwin/cloud-agnostic-core": "workspace:*",
-    "axios": "~0.24.0",
+    "axios": "~0.27.2",
     "inversify": "~5.0.1",
     "reflect-metadata": "~0.1.13"
   },
@@ -43,7 +43,7 @@
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.2",
     "@types/mocha": "^8.2.2",
-    "@types/node": "^14.14.41",
+    "@types/node": "~16.6.2",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cspell": "~5.18.5",
@@ -53,7 +53,7 @@
     "nyc": "^14.0.0",
     "rimraf": "^2.6.2",
     "sort-package-json": "~1.53.1",
-    "typescript": "~4.3.0"
+    "typescript": "~4.7.4"
   },
   "engines": {
     "node": ">=12.20 <17.0.0"

--- a/storage/core/src/server/Helpers.ts
+++ b/storage/core/src/server/Helpers.ts
@@ -129,6 +129,7 @@ export async function uploadToUrl(
   });
 }
 
+// TODO: switch to using crypto.randomUUID function once support for Node 12.x is dropped.
 export function getRandomString(): string {
   return randomBytes(16).toString("hex");
 }

--- a/storage/core/src/server/Helpers.ts
+++ b/storage/core/src/server/Helpers.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import { randomBytes } from "crypto";
 import { createReadStream, createWriteStream, promises } from "fs";
 import { dirname } from "path";
 import { Readable } from "stream";
@@ -126,4 +127,8 @@ export async function uploadToUrl(
   await axios.put(url, dataToUpload, {
     headers,
   });
+}
+
+export function getRandomString(): string {
+  return randomBytes(16).toString("hex");
 }

--- a/storage/minio/package.json
+++ b/storage/minio/package.json
@@ -59,7 +59,7 @@
     "@types/chai-as-promised": "^7.1.2",
     "@types/minio": "~7.0.11",
     "@types/mocha": "^8.2.2",
-    "@types/node": "^14.14.41",
+    "@types/node": "~16.6.2",
     "@types/sinon": "~10.0.11",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
@@ -72,7 +72,7 @@
     "rimraf": "^2.6.2",
     "sinon": "~14.0.0",
     "sort-package-json": "~1.53.1",
-    "typescript": "~4.3.0",
+    "typescript": "~4.7.4",
     "wait-on": "~6.0.1",
     "webpack": "~5.72.0",
     "webpack-cli": "~4.9.2"

--- a/storage/oss/package.json
+++ b/storage/oss/package.json
@@ -51,7 +51,7 @@
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.2",
     "@types/mocha": "^8.2.2",
-    "@types/node": "^14.14.41",
+    "@types/node": "~16.6.2",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cspell": "~5.18.5",
@@ -62,7 +62,7 @@
     "nyc": "^14.0.0",
     "rimraf": "^2.6.2",
     "sort-package-json": "~1.53.1",
-    "typescript": "~4.3.0",
+    "typescript": "~4.7.4",
     "wait-on": "~6.0.1",
     "webpack": "~5.72.0",
     "webpack-cli": "~4.9.2"

--- a/storage/oss/src/server/OssTransferConfigProvider.ts
+++ b/storage/oss/src/server/OssTransferConfigProvider.ts
@@ -2,13 +2,12 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { randomUUID } from "crypto";
-
 import * as Core from "@alicloud/pop-core";
 import { inject, injectable } from "inversify";
 
 import {
   buildObjectDirectoryString,
+  getRandomString,
   ObjectDirectory,
   TransferConfigProvider,
 } from "@itwin/object-storage-core";
@@ -55,7 +54,7 @@ export class OssTransferConfigProvider implements TransferConfigProvider {
       "AssumeRole",
       {
         RoleArn: this._config.roleArn,
-        RoleSessionName: randomUUID(),
+        RoleSessionName: getRandomString(),
         Policy: JSON.stringify(policy),
         DurationSeconds: expiresInSeconds,
       },
@@ -102,7 +101,7 @@ export class OssTransferConfigProvider implements TransferConfigProvider {
       "AssumeRole",
       {
         RoleArn: this._config.roleArn,
-        RoleSessionName: randomUUID(),
+        RoleSessionName: getRandomString(),
         Policy: JSON.stringify(policy),
         DurationSeconds: expiresInSeconds,
       },

--- a/storage/s3/package.json
+++ b/storage/s3/package.json
@@ -51,7 +51,7 @@
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.2",
     "@types/mocha": "^8.2.2",
-    "@types/node": "^14.14.41",
+    "@types/node": "~16.6.2",
     "@types/sinon": "~10.0.11",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
@@ -63,7 +63,7 @@
     "rimraf": "^2.6.2",
     "sinon": "~14.0.0",
     "sort-package-json": "~1.53.1",
-    "typescript": "~4.3.0"
+    "typescript": "~4.7.4"
   },
   "engines": {
     "node": ">=12.20 <17.0.0"

--- a/storage/s3/src/server/S3TransferConfigProvider.ts
+++ b/storage/s3/src/server/S3TransferConfigProvider.ts
@@ -2,13 +2,12 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { randomUUID } from "crypto";
-
 import { AssumeRoleCommand, STSClient } from "@aws-sdk/client-sts";
 import { inject, injectable } from "inversify";
 
 import {
   buildObjectDirectoryString,
+  getRandomString,
   ObjectDirectory,
   TransferConfigProvider,
 } from "@itwin/object-storage-core";
@@ -55,7 +54,7 @@ export class S3TransferConfigProvider implements TransferConfigProvider {
         DurationSeconds: expiresInSeconds,
         Policy: JSON.stringify(policy),
         RoleArn: this._config.roleArn,
-        RoleSessionName: randomUUID(),
+        RoleSessionName: getRandomString(),
       })
     );
     /* eslint-enable @typescript-eslint/naming-convention */
@@ -98,7 +97,7 @@ export class S3TransferConfigProvider implements TransferConfigProvider {
         DurationSeconds: expiresInSeconds,
         Policy: JSON.stringify(policy),
         RoleArn: this._config.roleArn,
-        RoleSessionName: randomUUID(),
+        RoleSessionName: getRandomString(),
       })
     );
     /* eslint-enable @typescript-eslint/naming-convention */

--- a/tests/backend-storage-unit/package.json
+++ b/tests/backend-storage-unit/package.json
@@ -44,12 +44,12 @@
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.2",
     "@types/mocha": "^8.2.2",
-    "@types/node": "^14.14.41",
+    "@types/node": "~16.6.2",
     "cspell": "~5.18.5",
     "eslint": "~7.32.0",
     "rimraf": "^2.6.2",
     "sort-package-json": "~1.53.1",
-    "typescript": "~4.3.0"
+    "typescript": "~4.7.4"
   },
   "engines": {
     "node": ">=12.20 <17.0.0"

--- a/tests/backend-storage/package.json
+++ b/tests/backend-storage/package.json
@@ -37,6 +37,7 @@
     "@itwin/object-storage-core": "workspace:*",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
+    "fs-extra": "~10.1.0",
     "inversify": "~5.0.1",
     "mocha": "^9.2.1",
     "reflect-metadata": "~0.1.13"
@@ -45,14 +46,15 @@
     "@itwin/object-storage-common-config": "workspace:*",
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.2",
+    "@types/fs-extra": "~9.0.13",
     "@types/mocha": "^8.2.2",
-    "@types/node": "^14.14.41",
+    "@types/node": "~16.6.2",
     "@types/yargs": "~15.0.5",
     "cspell": "~5.18.5",
     "eslint": "~7.32.0",
     "rimraf": "^2.6.2",
     "sort-package-json": "~1.53.1",
-    "typescript": "~4.3.0"
+    "typescript": "~4.7.4"
   },
   "engines": {
     "node": ">=12.20 <17.0.0"

--- a/tests/backend-storage/src/test/ServerStorage.test.ts
+++ b/tests/backend-storage/src/test/ServerStorage.test.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { randomUUID } from "crypto";
 import { createReadStream } from "fs";
 import * as path from "path";
 
@@ -11,6 +10,7 @@ import * as chaiAsPromised from "chai-as-promised";
 
 import {
   BaseDirectory,
+  getRandomString,
   Metadata,
   ObjectReference,
   ServerStorage,
@@ -35,7 +35,7 @@ describe(`${ServerStorage.name}: ${serverStorage.constructor.name}`, () => {
   describe(`${serverStorage.createBaseDirectory.name}()`, () => {
     it("should create directory", async () => {
       const testDirectory: BaseDirectory = {
-        baseDirectory: `test-create-directory-${randomUUID()}`,
+        baseDirectory: `test-create-directory-${getRandomString()}`,
       };
       testDirectoryManager.addForDelete(testDirectory);
 
@@ -328,7 +328,7 @@ describe(`${ServerStorage.name}: ${serverStorage.constructor.name}`, () => {
 
     it("should not throw if base directory does not exist", async () => {
       const deletePromise = serverStorage.deleteBaseDirectory({
-        baseDirectory: randomUUID(),
+        baseDirectory: getRandomString(),
       });
 
       await expect(deletePromise).to.eventually.be.fulfilled;
@@ -357,7 +357,7 @@ describe(`${ServerStorage.name}: ${serverStorage.constructor.name}`, () => {
       ).baseDirectory;
       const deletePromise = serverStorage.deleteObject({
         baseDirectory: testBaseDirectory.baseDirectory,
-        objectName: randomUUID(),
+        objectName: getRandomString(),
       });
 
       await expect(deletePromise).to.eventually.be.fulfilled;
@@ -365,9 +365,9 @@ describe(`${ServerStorage.name}: ${serverStorage.constructor.name}`, () => {
 
     it("should not throw if the whole path does not exist", async () => {
       const deletePromise = serverStorage.deleteObject({
-        baseDirectory: randomUUID(),
-        relativeDirectory: randomUUID(),
-        objectName: randomUUID(),
+        baseDirectory: getRandomString(),
+        relativeDirectory: getRandomString(),
+        objectName: getRandomString(),
       });
 
       await expect(deletePromise).to.eventually.be.fulfilled;
@@ -405,7 +405,7 @@ describe(`${ServerStorage.name}: ${serverStorage.constructor.name}`, () => {
 
     it("should return false if base directory does not exist", async () => {
       const exists = await serverStorage.baseDirectoryExists({
-        baseDirectory: randomUUID(),
+        baseDirectory: getRandomString(),
       });
 
       expect(exists).to.be.false;
@@ -434,7 +434,7 @@ describe(`${ServerStorage.name}: ${serverStorage.constructor.name}`, () => {
 
       const exists = await serverStorage.objectExists({
         baseDirectory: testBaseDirectory.baseDirectory,
-        objectName: randomUUID(),
+        objectName: getRandomString(),
       });
 
       expect(exists).to.be.false;
@@ -442,9 +442,9 @@ describe(`${ServerStorage.name}: ${serverStorage.constructor.name}`, () => {
 
     it("should return false if the whole path does not exist", async () => {
       const exists = await serverStorage.objectExists({
-        baseDirectory: randomUUID(),
-        relativeDirectory: randomUUID(),
-        objectName: randomUUID(),
+        baseDirectory: getRandomString(),
+        relativeDirectory: getRandomString(),
+        objectName: getRandomString(),
       });
 
       expect(exists).to.be.false;

--- a/tests/backend-storage/src/test/utils/TestRemoteDirectory.ts
+++ b/tests/backend-storage/src/test/utils/TestRemoteDirectory.ts
@@ -2,10 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { randomUUID } from "crypto";
-
 import {
   BaseDirectory,
+  getRandomString,
   Metadata,
   ObjectReference,
 } from "@itwin/object-storage-core";
@@ -23,7 +22,7 @@ export class TestRemoteDirectory {
     metadata: Metadata | undefined
   ): Promise<ObjectReference> {
     const contentToUpload: Buffer =
-      content ?? Buffer.from(`test file payload ${randomUUID()}`);
+      content ?? Buffer.from(`test file payload ${getRandomString()}`);
     const objectReference: ObjectReference = {
       baseDirectory: this.baseDirectory.baseDirectory,
       ...reference,

--- a/tests/backend-storage/src/test/utils/TestRemoteDirectoryManager.ts
+++ b/tests/backend-storage/src/test/utils/TestRemoteDirectoryManager.ts
@@ -2,9 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { randomUUID } from "crypto";
-
-import { BaseDirectory } from "@itwin/object-storage-core";
+import { BaseDirectory, getRandomString } from "@itwin/object-storage-core";
 
 import { config } from "../Config";
 
@@ -17,7 +15,7 @@ export class TestRemoteDirectoryManager {
 
   public async createNew(): Promise<TestRemoteDirectory> {
     const newDirectory: BaseDirectory = {
-      baseDirectory: `integration-tests-${randomUUID()}`,
+      baseDirectory: `integration-tests-${getRandomString()}`,
     };
     this.addForDelete(newDirectory);
     await serverStorage.createBaseDirectory(newDirectory);

--- a/tests/frontend-storage/package.json
+++ b/tests/frontend-storage/package.json
@@ -41,15 +41,15 @@
   "devDependencies": {
     "@itwin/object-storage-common-config": "workspace:*",
     "@types/express": "~4.17.13",
-    "@types/node": "^14.14.41",
-    "axios": "~0.24.0",
+    "@types/node": "~16.6.2",
+    "axios": "~0.27.2",
     "cross-env": "~7.0.3",
     "cspell": "~5.18.5",
     "eslint": "~7.32.0",
     "express": "~4.18.0",
     "rimraf": "^2.6.2",
     "sort-package-json": "~1.53.1",
-    "typescript": "~4.3.0"
+    "typescript": "~4.7.4"
   },
   "engines": {
     "node": ">=12.20 <17.0.0"


### PR DESCRIPTION
In this PR:
- Updated the repository to support Node 12 to 16 versions:
  - Changes in rush.json
  - Removed usage of `fs` methods that are unsupported in Node 12
  - Updated release pipeline to run build on both Node 12 and Node 16 before release
- Updated typescript version

**Note**: Ideally in pipelines we should specify to use the latest release of a major LTS version (`16.x` instead of `16.15.0`) to use the release with latest security fixes. This is not the case now as the latest release of Node 16 includes npm version which in combination with that Node version produces build warnings on Windows:
![image](https://user-images.githubusercontent.com/70565417/178715887-24e4311d-260b-4417-b00b-9b311e96655c.png)
[Link to GitHub issue for npm/cli](https://github.com/npm/cli/issues/4989)
None of the workarounds seem applicable for use in pipelines.

**Note:** I have disabled frontend integration tests on Node 12 builds because they consume time and resources and they also run in browser. There is no need to test if tests infrastructure works on different Node versions.