### PR TITLE
Support for cancelling downloads in `ClientStorage`

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -313,6 +313,7 @@ importers:
       '@aws-sdk/client-sts': 3.105.0
       '@aws-sdk/lib-storage': 3.105.0
       '@aws-sdk/s3-request-presigner': 3.105.0
+      '@aws-sdk/types': 3.78.0
       '@itwin/cloud-agnostic-core': workspace:*
       '@itwin/object-storage-common-config': workspace:*
       '@itwin/object-storage-core': workspace:*
@@ -345,6 +346,7 @@ importers:
       inversify: 5.0.5
       reflect-metadata: 0.1.13
     devDependencies:
+      '@aws-sdk/types': 3.78.0
       '@itwin/object-storage-common-config': link:../../utils/common-config
       '@itwin/object-storage-tests-backend-unit': link:../../tests/backend-storage-unit
       '@types/chai': 4.3.0
@@ -375,6 +377,7 @@ importers:
       '@types/mocha': ^8.2.2
       '@types/node': ~16.6.2
       '@types/yargs': ~15.0.5
+      abort-controller: ~3.0.0
       chai: ^4.2.0
       chai-as-promised: ^7.1.1
       cspell: ~5.18.5
@@ -389,6 +392,7 @@ importers:
     dependencies:
       '@itwin/cloud-agnostic-core': link:../../cloud-agnostic/core
       '@itwin/object-storage-core': link:../../storage/core
+      abort-controller: 3.0.0
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
       fs-extra: 10.1.0
@@ -1247,7 +1251,6 @@ packages:
   /@aws-sdk/types/3.78.0:
     resolution: {integrity: sha512-I9PTlVNSbwhIgMfmDM5as1tqRIkVZunjVmfogb2WVVPp4CaX0Ll01S0FSMSLL9k6tcQLXqh45pFRjrxCl9WKdQ==}
     engines: {node: '>= 12.0.0'}
-    dev: false
 
   /@aws-sdk/url-parser/3.78.0:
     resolution: {integrity: sha512-iQn2AjECUoJE0Ae9XtgHtGGKvUkvE8hhbktGopdj+zsPBe4WrBN2DgVxlKPPrBonG/YlcL1D7a5EXaujWSlUUw==}
@@ -2648,6 +2651,13 @@ packages:
     resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
     dev: false
     optional: true
+
+  /abort-controller/3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+    dependencies:
+      event-target-shim: 5.0.1
+    dev: false
 
   /accepts/1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -4253,6 +4263,11 @@ packages:
     resolution: {integrity: sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=}
     engines: {node: '>= 0.6'}
     dev: true
+
+  /event-target-shim/5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+    dev: false
 
   /eventemitter2/6.4.5:
     resolution: {integrity: sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==}

--- a/storage/azure/src/client/AzureClientStorage.ts
+++ b/storage/azure/src/client/AzureClientStorage.ts
@@ -6,6 +6,7 @@ import { promises } from "fs";
 import { dirname } from "path";
 import { Readable } from "stream";
 
+import { BlobDownloadOptions } from "@azure/storage-blob";
 import { inject, injectable } from "inversify";
 
 import { assertRelativeDirectory } from "@itwin/object-storage-core/lib/common/internal";
@@ -67,9 +68,13 @@ export class AzureClientStorage extends ClientStorage {
     if (isLocalTransferInput(input))
       await promises.mkdir(dirname(input.localPath), { recursive: true });
 
+    const options: BlobDownloadOptions = {
+      abortSignal: input.abortSignal,
+    };
+
     const downloadStream = await this._clientWrapperFactory
       .create(input)
-      .download();
+      .download(options);
 
     return streamToTransferType(
       downloadStream,

--- a/storage/azure/src/server/wrappers/BlockBlobClientWrapper.ts
+++ b/storage/azure/src/server/wrappers/BlockBlobClientWrapper.ts
@@ -4,7 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 import { Readable } from "stream";
 
-import { BlockBlobClient, Metadata } from "@azure/storage-blob";
+import {
+  BlobDownloadOptions,
+  BlockBlobClient,
+  Metadata,
+} from "@azure/storage-blob";
 
 import {
   MultipartUploadData,
@@ -15,8 +19,12 @@ import {
 export class BlockBlobClientWrapper {
   constructor(private readonly _client: BlockBlobClient) {}
 
-  public async download(): Promise<Readable> {
-    const downloadResponse = await this._client.download();
+  public async download(options?: BlobDownloadOptions): Promise<Readable> {
+    const downloadResponse = await this._client.download(
+      undefined,
+      undefined,
+      options
+    );
     return downloadResponse.readableStreamBody! as Readable;
   }
 

--- a/storage/core/src/server/Interfaces.ts
+++ b/storage/core/src/server/Interfaces.ts
@@ -17,9 +17,21 @@ export type TransferType = "buffer" | "stream" | "local";
 export type TransferData = Readable | Buffer | string;
 export type MultipartUploadData = Readable | string;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AbortSignalListener = (this: any, ev: any) => any;
+
+export interface AbortSignal {
+  aborted: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onabort: ((this: any, ev: any) => any) | null;
+  addEventListener: (type: "abort", listener: AbortSignalListener) => void;
+  removeEventListener: (type: "abort", listener: AbortSignalListener) => void;
+}
+
 export interface UrlDownloadInput extends UrlTransferInput {
   transferType: TransferType;
   localPath?: string;
+  abortSignal?: AbortSignal;
 }
 
 export interface UrlUploadInput extends UrlTransferInput {
@@ -30,6 +42,7 @@ export interface UrlUploadInput extends UrlTransferInput {
 export interface ConfigDownloadInput extends ConfigTransferInput {
   transferType: TransferType;
   localPath?: string;
+  abortSignal?: AbortSignal;
 }
 
 export interface ConfigUploadInput extends ConfigTransferInput {

--- a/storage/core/src/server/Interfaces.ts
+++ b/storage/core/src/server/Interfaces.ts
@@ -18,7 +18,7 @@ export type TransferData = Readable | Buffer | string;
 export type MultipartUploadData = Readable | string;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AbortSignalListener = (this: any, ev: any) => any;
+export type AbortSignalListener = (this: AbortSignal, ev: any) => any;
 
 export interface AbortSignal {
   aborted: boolean;

--- a/storage/core/src/server/Interfaces.ts
+++ b/storage/core/src/server/Interfaces.ts
@@ -18,9 +18,9 @@ export type TransferData = Readable | Buffer | string;
 export type MultipartUploadData = Readable | string;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AbortSignalListener = (this: AbortSignal, ev: any) => any;
+export type AbortSignalListener = (this: GenericAbortSignal, ev: any) => any;
 
-export interface AbortSignal {
+export interface GenericAbortSignal {
   aborted: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onabort: ((this: any, ev: any) => any) | null;
@@ -31,7 +31,7 @@ export interface AbortSignal {
 export interface UrlDownloadInput extends UrlTransferInput {
   transferType: TransferType;
   localPath?: string;
-  abortSignal?: AbortSignal;
+  abortSignal?: GenericAbortSignal;
 }
 
 export interface UrlUploadInput extends UrlTransferInput {
@@ -42,7 +42,7 @@ export interface UrlUploadInput extends UrlTransferInput {
 export interface ConfigDownloadInput extends ConfigTransferInput {
   transferType: TransferType;
   localPath?: string;
-  abortSignal?: AbortSignal;
+  abortSignal?: GenericAbortSignal;
 }
 
 export interface ConfigUploadInput extends ConfigTransferInput {

--- a/storage/core/src/server/internal/Helpers.ts
+++ b/storage/core/src/server/internal/Helpers.ts
@@ -90,18 +90,24 @@ export async function downloadFromUrl(
   input: UrlDownloadInput
 ): Promise<TransferData> {
   const { transferType, url } = input;
+
+  // There is an issue with Axios type definitions. Casting should be removed
+  // after upgrading to Axios 1.0
+  // See: https://github.com/axios/axios/pull/4229
+  const signal = input.abortSignal as AbortSignal | undefined;
+
   switch (transferType) {
     case "buffer":
-      return (await axios.get(url, { responseType: "arraybuffer" }))
+      return (await axios.get(url, { responseType: "arraybuffer", signal }))
         .data as Buffer;
     case "stream":
-      return (await axios.get(url, { responseType: "stream" }))
+      return (await axios.get(url, { responseType: "stream", signal }))
         .data as Readable;
     case "local":
       const localPath = input.localPath;
       assertLocalFile(localPath);
 
-      const stream = (await axios.get(url, { responseType: "stream" }))
+      const stream = (await axios.get(url, { responseType: "stream", signal }))
         .data as Readable;
       await streamToLocalFile(stream, localPath);
 

--- a/storage/s3/package.json
+++ b/storage/s3/package.json
@@ -46,6 +46,7 @@
     "reflect-metadata": "~0.1.13"
   },
   "devDependencies": {
+    "@aws-sdk/types": "3.78.0",
     "@itwin/object-storage-common-config": "workspace:*",
     "@itwin/object-storage-tests-backend-unit": "workspace:*",
     "@types/chai": "^4.1.7",

--- a/storage/s3/src/client/S3ClientStorage.ts
+++ b/storage/s3/src/client/S3ClientStorage.ts
@@ -5,6 +5,7 @@
 import { createReadStream } from "fs";
 import { Readable } from "stream";
 
+import type { HttpHandlerOptions } from "@aws-sdk/types";
 import { inject, injectable } from "inversify";
 
 import {
@@ -67,10 +68,17 @@ export class S3ClientStorage extends ClientStorage {
     if (instanceOfUrlTransferInput(input)) return downloadFromUrl(input);
     else assertRelativeDirectory(input.reference.relativeDirectory);
 
+    const options: HttpHandlerOptions = {
+      abortSignal: input.abortSignal,
+    };
+
     return createAndUseClient(
       () => this._clientWrapperFactory.create(input.transferConfig),
       async (clientWrapper: S3ClientWrapper) => {
-        const downloadStream = await clientWrapper.download(input.reference);
+        const downloadStream = await clientWrapper.download(
+          input.reference,
+          options
+        );
         return streamToTransferType(
           downloadStream,
           input.transferType,

--- a/storage/s3/src/server/wrappers/S3ClientWrapper.ts
+++ b/storage/s3/src/server/wrappers/S3ClientWrapper.ts
@@ -15,6 +15,7 @@ import {
   S3Client,
 } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
+import type { HttpHandlerOptions } from "@aws-sdk/types";
 import { inject, injectable } from "inversify";
 
 import {
@@ -42,13 +43,17 @@ export class S3ClientWrapper {
     @inject(Types.bucket) protected readonly _bucket: string
   ) {}
 
-  public async download(reference: ObjectReference): Promise<Readable> {
+  public async download(
+    reference: ObjectReference,
+    options?: HttpHandlerOptions
+  ): Promise<Readable> {
     /* eslint-disable @typescript-eslint/naming-convention */
     const { Body } = await this._client.send(
       new GetObjectCommand({
         Bucket: this._bucket,
         Key: buildObjectKey(reference),
-      })
+      }),
+      options
     );
     /* eslint-enable @typescript-eslint/naming-convention */
 

--- a/tests/backend-storage/package.json
+++ b/tests/backend-storage/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@itwin/cloud-agnostic-core": "workspace:*",
     "@itwin/object-storage-core": "workspace:*",
+    "abort-controller": "~3.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "fs-extra": "~10.1.0",

--- a/tests/backend-storage/src/test/ClientStorage.test.ts
+++ b/tests/backend-storage/src/test/ClientStorage.test.ts
@@ -194,7 +194,8 @@ describe(`${ClientStorage.name}: ${clientStorage.constructor.name}`, () => {
         try {
           await downloadPromise;
         } catch (error: unknown) {
-          wasAborted = true;
+          if (error instanceof Error && error.name === "AbortError")
+            wasAborted = true;
         }
 
         expect(wasAborted).to.be.true;
@@ -448,7 +449,8 @@ describe(`${ClientStorage.name}: ${clientStorage.constructor.name}`, () => {
         try {
           await downloadPromise;
         } catch (error: unknown) {
-          wasAborted = true;
+          if (error instanceof Error && error.name === "AbortError")
+            wasAborted = true;
         }
 
         expect(wasAborted).to.be.true;

--- a/tests/backend-storage/src/test/ClientStorage.test.ts
+++ b/tests/backend-storage/src/test/ClientStorage.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as path from "path";
 
+import { AbortController } from "abort-controller";
 import { expect, use } from "chai";
 import * as chaiAsPromised from "chai-as-promised";
 
@@ -163,6 +164,40 @@ describe(`${ClientStorage.name}: ${clientStorage.constructor.name}`, () => {
         });
 
         await assertLocalFile(response, contentBuffer);
+      });
+
+      it(`should cancel file download from URL`, async () => {
+        const contentBuffer = Buffer.from("test-download-from-url-to-path");
+        const testDownloadPath: string =
+          await testLocalFileManager.getDownloadsDir();
+        const testDirectory: TestRemoteDirectory =
+          await testDirectoryManager.createNew();
+        const uploadedFile: ObjectReference = await testDirectory.uploadFile(
+          { objectName: "file-to-download-from-url.txt" },
+          contentBuffer,
+          undefined
+        );
+
+        const downloadUrl = await serverStorage.getDownloadUrl(uploadedFile);
+        const abortController = new AbortController();
+
+        const downloadPromise = clientStorage.download({
+          url: downloadUrl,
+          transferType: "local",
+          localPath: `${testDownloadPath}/download-url.txt`,
+          abortSignal: abortController.signal,
+        });
+
+        abortController.abort();
+
+        let wasAborted = false;
+        try {
+          await downloadPromise;
+        } catch (error: unknown) {
+          wasAborted = true;
+        }
+
+        expect(wasAborted).to.be.true;
       });
     });
   });
@@ -380,6 +415,43 @@ describe(`${ClientStorage.name}: ${clientStorage.constructor.name}`, () => {
         });
 
         await assertLocalFile(response, contentBuffer);
+      });
+
+      it(`should cancel file download to path using transfer config`, async () => {
+        const contentBuffer = Buffer.from("test-download-to-path-with-config");
+        const testDownloadPath: string =
+          await testLocalFileManager.getDownloadsDir();
+        const testDirectory: TestRemoteDirectory =
+          await testDirectoryManager.createNew();
+        const uploadedFile: ObjectReference = await testDirectory.uploadFile(
+          { objectName: "file-to-download-with-config.txt" },
+          contentBuffer,
+          undefined
+        );
+
+        const downloadConfig = await serverStorage.getDownloadConfig(
+          testDirectory.baseDirectory
+        );
+        const abortController = new AbortController();
+
+        const downloadPromise = clientStorage.download({
+          reference: uploadedFile,
+          transferConfig: downloadConfig,
+          transferType: "local",
+          localPath: path.join(testDownloadPath, "download-config.txt"),
+          abortSignal: abortController.signal,
+        });
+
+        abortController.abort();
+
+        let wasAborted = false;
+        try {
+          await downloadPromise;
+        } catch (error: unknown) {
+          wasAborted = true;
+        }
+
+        expect(wasAborted).to.be.true;
       });
     });
   });


### PR DESCRIPTION
## Motivation

Right now `ClientStorage` does not expose any way to cancel downloads. This prevents implementing features like: [PR #3735: Progress API for downloading changesets](https://github.com/iTwin/itwinjs-core/pull/3735).

## Changes

New dependency:
- [abort-controller 3.0.0](https://www.npmjs.com/package/abort-controller) in `@itwin/object-storage-tests-backend`.


API changes:
- Added custom defined `GenericAbortSignal` interface.
- `ClientStorage.download` now takes `abortSignal` as optional paramater.