### PR TITLE
1.2.0 -> 1.3.0 version bump 

### DIFF
--- a/cloud-agnostic/core/package.json
+++ b/cloud-agnostic/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/cloud-agnostic-core",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Package that allows configuring components loaded by dependency injection",
   "keywords": [
     "Bentley",

--- a/samples/package.json
+++ b/samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/object-storage-samples",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Samples that demonstrate object storage component usage.",
   "keywords": [
     "Bentley",

--- a/storage/azure/package.json
+++ b/storage/azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/object-storage-azure",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Object storage implementation using Azure Blob Storage",
   "keywords": [
     "Bentley",

--- a/storage/core/package.json
+++ b/storage/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/object-storage-core",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Core generic object storage interfaces",
   "keywords": [
     "Bentley",

--- a/storage/minio/package.json
+++ b/storage/minio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/object-storage-minio",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Object storage implementation using Minio",
   "keywords": [
     "Bentley",

--- a/storage/oss/package.json
+++ b/storage/oss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/object-storage-oss",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Object storage implementation using OSS",
   "keywords": [
     "Bentley",

--- a/storage/s3/package.json
+++ b/storage/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/object-storage-s3",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Object storage implementation base for S3 compatible providers",
   "keywords": [
     "Bentley",

--- a/tests/backend-storage-unit/package.json
+++ b/tests/backend-storage-unit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/object-storage-tests-backend-unit",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "keywords": [
     "Bentley",
     "iTwin",

--- a/tests/backend-storage/package.json
+++ b/tests/backend-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/object-storage-tests-backend",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Tests for generic storage packages",
   "keywords": [
     "Bentley",

--- a/tests/frontend-storage/package.json
+++ b/tests/frontend-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/object-storage-tests-frontend",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "keywords": [
     "Bentley",
     "iTwin",

--- a/utils/common-config/package.json
+++ b/utils/common-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/object-storage-common-config",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Common configuration for object storage packages",
   "repository": {
     "type": "git",


### PR DESCRIPTION
In this PR:
- Bumped the version to release the following changes: https://github.com/iTwin/object-storage/pull/59