### PR TITLE
`pnpm` downgrade

### DIFF
--- a/common/config/azure-pipelines/build-test.yml
+++ b/common/config/azure-pipelines/build-test.yml
@@ -8,7 +8,6 @@ parameters:
 
 variables:
   node18Version: '18.13.0'
-  node12Version: '12.17.0'
 
 trigger: none
 
@@ -24,14 +23,6 @@ jobs:
           imageName: 'windows-latest'
           nodeVersion: $(node18Version)
           runFrontendIntegrationTests: true
-        linux-node-12:
-          imageName: 'ubuntu-latest'
-          nodeVersion: $(node12Version)
-          runFrontendIntegrationTests: false
-        windows-node-12:
-          imageName: 'windows-latest'
-          nodeVersion: $(node12Version)
-          runFrontendIntegrationTests: false
     pool:
         vmImage: $(imageName)
     variables:

--- a/common/config/azure-pipelines/build-test.yml
+++ b/common/config/azure-pipelines/build-test.yml
@@ -8,6 +8,7 @@ parameters:
 
 variables:
   node18Version: '18.13.0'
+  node12Version: '12.17.0'
 
 trigger: none
 
@@ -23,6 +24,14 @@ jobs:
           imageName: 'windows-latest'
           nodeVersion: $(node18Version)
           runFrontendIntegrationTests: true
+        linux-node-12:
+          imageName: 'ubuntu-latest'
+          nodeVersion: $(node12Version)
+          runFrontendIntegrationTests: false
+        windows-node-12:
+          imageName: 'windows-latest'
+          nodeVersion: $(node12Version)
+          runFrontendIntegrationTests: false
     pool:
         vmImage: $(imageName)
     variables:

--- a/rush.json
+++ b/rush.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
   "rushVersion": "5.88.0",
-  "pnpmVersion": "7.24.3",
+  "pnpmVersion": "6.13.0",
   "nodeSupportedVersionRange": ">=12.17.0 <19.0.0",
   "ensureConsistentVersions": true,
   "projectFolderMinDepth": 1,


### PR DESCRIPTION
In this PR:
- Downgraded `pnpm` version to what it was before [Support for Node 18](https://github.com/iTwin/object-storage/pull/69) PR.