### PR TITLE
Remove Node 12, Node 16 support

### DIFF
--- a/common/config/azure-pipelines/build-test-publish.yml
+++ b/common/config/azure-pipelines/build-test-publish.yml
@@ -8,8 +8,6 @@ parameters:
 
 variables:
   node18Version: '18.13.0'
-  node16Version: '16.15.0'
-  node12Version: '12.17.0'
 
 trigger: none
 
@@ -25,22 +23,6 @@ jobs:
           imageName: 'windows-latest'
           nodeVersion: $(node18Version)
           runFrontendIntegrationTests: true
-        linux-node-16:
-          imageName: 'ubuntu-latest'
-          nodeVersion: $(node16Version)
-          runFrontendIntegrationTests: true
-        windows-node-16:
-          imageName: 'windows-latest'
-          nodeVersion: $(node16Version)
-          runFrontendIntegrationTests: true
-        linux-node-12:
-          imageName: 'ubuntu-latest'
-          nodeVersion: $(node12Version)
-          runFrontendIntegrationTests: false
-        windows-node-12:
-          imageName: 'windows-latest'
-          nodeVersion: $(node12Version)
-          runFrontendIntegrationTests: false
     pool:
         vmImage: $(imageName)
     variables:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
       '@itwin/object-storage-azure': workspace:*
       '@itwin/object-storage-common-config': workspace:*
       '@itwin/object-storage-core': workspace:*
-      '@types/node': ~18.11.18
+      '@types/node': ^18.11.18
       cspell: ~5.18.5
       eslint: ^8.42.0
       inversify: ^6.0.1
@@ -83,7 +83,7 @@ importers:
       '@types/chai': ^4.1.7
       '@types/chai-as-promised': ^7.1.2
       '@types/mocha': ~10.0.1
-      '@types/node': ~18.11.18
+      '@types/node': ^18.11.18
       '@types/sinon': ~10.0.11
       chai: ^4.2.0
       chai-as-promised: ^7.1.1
@@ -144,7 +144,7 @@ importers:
       '@types/chai': ^4.1.7
       '@types/chai-as-promised': ^7.1.2
       '@types/mocha': ~10.0.1
-      '@types/node': ~18.11.18
+      '@types/node': ^18.11.18
       axios: ~0.27.2
       chai: ^4.2.0
       chai-as-promised: ^7.1.1
@@ -196,7 +196,7 @@ importers:
       '@types/chai-as-promised': ^7.1.2
       '@types/minio': ~7.0.11
       '@types/mocha': ~10.0.1
-      '@types/node': ~18.11.18
+      '@types/node': ^18.11.18
       '@types/sinon': ~10.0.11
       chai: ^4.2.0
       chai-as-promised: ^7.1.1
@@ -267,7 +267,7 @@ importers:
       '@types/chai': ^4.1.7
       '@types/chai-as-promised': ^7.1.2
       '@types/mocha': ~10.0.1
-      '@types/node': ~18.11.18
+      '@types/node': ^18.11.18
       chai: ^4.2.0
       chai-as-promised: ^7.1.1
       cspell: ~5.18.5
@@ -333,7 +333,7 @@ importers:
       '@types/chai': ^4.1.7
       '@types/chai-as-promised': ^7.1.2
       '@types/mocha': ~10.0.1
-      '@types/node': ~18.11.18
+      '@types/node': ^18.11.18
       '@types/sinon': ~10.0.11
       chai: ^4.2.0
       chai-as-promised: ^7.1.1
@@ -390,7 +390,7 @@ importers:
       '@types/chai-as-promised': ^7.1.2
       '@types/fs-extra': ~9.0.13
       '@types/mocha': ~10.0.1
-      '@types/node': ~18.11.18
+      '@types/node': ^18.11.18
       '@types/yargs': ~15.0.5
       abort-controller: ~3.0.0
       chai: ^4.2.0
@@ -436,7 +436,7 @@ importers:
       '@types/chai': ^4.1.7
       '@types/chai-as-promised': ^7.1.2
       '@types/mocha': ~10.0.1
-      '@types/node': ~18.11.18
+      '@types/node': ^18.11.18
       chai: ^4.2.0
       chai-as-promised: ^7.1.1
       cspell: ~5.18.5
@@ -471,7 +471,7 @@ importers:
       '@itwin/object-storage-common-config': workspace:*
       '@itwin/object-storage-core': workspace:*
       '@types/express': ~4.17.13
-      '@types/node': ~18.11.18
+      '@types/node': ^18.11.18
       axios: ~0.27.2
       cross-env: ~7.0.3
       cspell: ~5.18.5

--- a/rush.json
+++ b/rush.json
@@ -2,7 +2,7 @@
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
   "rushVersion": "5.88.0",
   "pnpmVersion": "6.13.0",
-  "nodeSupportedVersionRange": ">=12.17.0 <19.0.0",
+  "nodeSupportedVersionRange": "^18.12.0",
   "ensureConsistentVersions": true,
   "projectFolderMinDepth": 1,
   "projectFolderMaxDepth": 2,

--- a/samples/package.json
+++ b/samples/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@itwin/object-storage-common-config": "workspace:*",
-    "@types/node": "~18.11.18",
+    "@types/node": "^18.11.18",
     "cspell": "~5.18.5",
     "eslint": "^8.42.0",
     "rimraf": "^2.6.2",

--- a/storage/azure/package.json
+++ b/storage/azure/package.json
@@ -58,7 +58,7 @@
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.2",
     "@types/mocha": "~10.0.1",
-    "@types/node": "~18.11.18",
+    "@types/node": "^18.11.18",
     "@types/sinon": "~10.0.11",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/storage/core/package.json
+++ b/storage/core/package.json
@@ -48,7 +48,7 @@
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.2",
     "@types/mocha": "~10.0.1",
-    "@types/node": "~18.11.18",
+    "@types/node": "^18.11.18",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cspell": "~5.18.5",

--- a/storage/minio/package.json
+++ b/storage/minio/package.json
@@ -66,7 +66,7 @@
     "@types/chai-as-promised": "^7.1.2",
     "@types/minio": "~7.0.11",
     "@types/mocha": "~10.0.1",
-    "@types/node": "~18.11.18",
+    "@types/node": "^18.11.18",
     "@types/sinon": "~10.0.11",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/storage/oss/package.json
+++ b/storage/oss/package.json
@@ -56,7 +56,7 @@
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.2",
     "@types/mocha": "~10.0.1",
-    "@types/node": "~18.11.18",
+    "@types/node": "^18.11.18",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cspell": "~5.18.5",

--- a/storage/s3/package.json
+++ b/storage/s3/package.json
@@ -60,7 +60,7 @@
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.2",
     "@types/mocha": "~10.0.1",
-    "@types/node": "~18.11.18",
+    "@types/node": "^18.11.18",
     "@types/sinon": "~10.0.11",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/tests/backend-storage-unit/package.json
+++ b/tests/backend-storage-unit/package.json
@@ -49,7 +49,7 @@
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.2",
     "@types/mocha": "~10.0.1",
-    "@types/node": "~18.11.18",
+    "@types/node": "^18.11.18",
     "cspell": "~5.18.5",
     "eslint": "^8.42.0",
     "rimraf": "^2.6.2",

--- a/tests/backend-storage/package.json
+++ b/tests/backend-storage/package.json
@@ -54,7 +54,7 @@
     "@types/chai-as-promised": "^7.1.2",
     "@types/fs-extra": "~9.0.13",
     "@types/mocha": "~10.0.1",
-    "@types/node": "~18.11.18",
+    "@types/node": "^18.11.18",
     "@types/yargs": "~15.0.5",
     "cspell": "~5.18.5",
     "eslint": "^8.42.0",

--- a/tests/frontend-storage/package.json
+++ b/tests/frontend-storage/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@itwin/object-storage-common-config": "workspace:*",
     "@types/express": "~4.17.13",
-    "@types/node": "~18.11.18",
+    "@types/node": "^18.11.18",
     "axios": "~0.27.2",
     "cross-env": "~7.0.3",
     "cspell": "~5.18.5",


### PR DESCRIPTION
In this PR:
- Changed rush.json to declare that we only support Node 18
- Removed test runs against old node versions from pipeline