### PR TITLE
Publish pipeline fix

### DIFF
--- a/common/config/azure-pipelines/templates/publish.yml
+++ b/common/config/azure-pipelines/templates/publish.yml
@@ -1,8 +1,8 @@
 steps:
   - task: NodeTool@0
-    displayName: Install Node@$(node16Version)
+    displayName: Install Node@$(node18Version)
     inputs:
-      versionSpec: $(node16Version)
+      versionSpec: $(node18Version)
       checkLatest: true
 
   - script: node common/scripts/install-run-rush.js install --purge


### PR DESCRIPTION
In this PR:
- Fixed publish step to use `node18Version` variable instead on non-existing `node16Version`