### PR TITLE
Make `reflect-metadata` a peer dependency

### DIFF
--- a/cloud-agnostic/core/package.json
+++ b/cloud-agnostic/core/package.json
@@ -46,13 +46,14 @@
     "inversify": "^6.0.1",
     "mocha": "~10.2.0",
     "nyc": "^14.0.0",
-    "reflect-metadata": "~0.1.13",
+    "reflect-metadata": "^0.1.13",
     "rimraf": "^2.6.2",
     "sort-package-json": "~1.53.1",
     "typescript": "^5.1.3"
   },
   "peerDependencies": {
-    "inversify": "^6.0.1"
+    "inversify": "^6.0.1",
+    "reflect-metadata": "^0.1.13"
   },
   "engines": {
     "node": ">=12.20 <19.0.0"

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
       inversify: ^6.0.1
       mocha: ~10.2.0
       nyc: ^14.0.0
-      reflect-metadata: ~0.1.13
+      reflect-metadata: ^0.1.13
       rimraf: ^2.6.2
       sort-package-json: ~1.53.1
       typescript: ^5.1.3
@@ -50,7 +50,7 @@ importers:
       cspell: ~5.18.5
       eslint: ^8.42.0
       inversify: ^6.0.1
-      reflect-metadata: ~0.1.13
+      reflect-metadata: ^0.1.13
       rimraf: ^2.6.2
       sort-package-json: ~1.53.1
       typescript: ^5.1.3
@@ -94,7 +94,7 @@ importers:
       mocha: ~10.2.0
       npm-run-all: ~4.1.5
       nyc: ^14.0.0
-      reflect-metadata: ~0.1.13
+      reflect-metadata: ^0.1.13
       rimraf: ^2.6.2
       sinon: ~14.0.0
       sort-package-json: ~1.53.1
@@ -153,7 +153,7 @@ importers:
       inversify: ^6.0.1
       mocha: ~10.2.0
       nyc: ^14.0.0
-      reflect-metadata: ~0.1.13
+      reflect-metadata: ^0.1.13
       rimraf: ^2.6.2
       sort-package-json: ~1.53.1
       typescript: ^5.1.3
@@ -207,7 +207,7 @@ importers:
       mocha: ~10.2.0
       npm-run-all: ~4.1.5
       nyc: ^14.0.0
-      reflect-metadata: ~0.1.13
+      reflect-metadata: ^0.1.13
       rimraf: ^2.6.2
       sinon: ~14.0.0
       sort-package-json: ~1.53.1
@@ -276,7 +276,7 @@ importers:
       mocha: ~10.2.0
       npm-run-all: ~4.1.5
       nyc: ^14.0.0
-      reflect-metadata: ~0.1.13
+      reflect-metadata: ^0.1.13
       rimraf: ^2.6.2
       sort-package-json: ~1.53.1
       typescript: ^5.1.3
@@ -342,7 +342,7 @@ importers:
       inversify: ^6.0.1
       mocha: ~10.2.0
       nyc: ^14.0.0
-      reflect-metadata: ~0.1.13
+      reflect-metadata: ^0.1.13
       rimraf: ^2.6.2
       sinon: ~14.0.0
       sort-package-json: ~1.53.1
@@ -399,7 +399,7 @@ importers:
       fs-extra: ~10.1.0
       inversify: ^6.0.1
       mocha: ~10.2.0
-      reflect-metadata: ~0.1.13
+      reflect-metadata: ^0.1.13
       rimraf: ^2.6.2
       sort-package-json: ~1.53.1
       typescript: ^5.1.3
@@ -4432,7 +4432,7 @@ packages:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 4.46.0_webpack-cli@4.9.2
+      webpack: 4.46.0
     dev: true
 
   /babel-plugin-add-module-exports/1.0.4:
@@ -9371,7 +9371,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.1
-      webpack: 4.46.0_webpack-cli@4.9.2
+      webpack: 4.46.0
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     dev: true
@@ -9536,7 +9536,7 @@ packages:
       micromatch: 4.0.5
       semver: 7.5.1
       typescript: 5.1.3
-      webpack: 4.46.0_webpack-cli@4.9.2
+      webpack: 4.46.0
     dev: true
 
   /ts-pnp/1.2.0_typescript@5.1.3:

--- a/samples/package.json
+++ b/samples/package.json
@@ -36,7 +36,7 @@
     "@itwin/object-storage-azure": "workspace:*",
     "@itwin/object-storage-core": "workspace:*",
     "inversify": "^6.0.1",
-    "reflect-metadata": "~0.1.13"
+    "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
     "@itwin/object-storage-common-config": "workspace:*",

--- a/storage/azure/package.json
+++ b/storage/azure/package.json
@@ -68,7 +68,7 @@
     "mocha": "~10.2.0",
     "npm-run-all": "~4.1.5",
     "nyc": "^14.0.0",
-    "reflect-metadata": "~0.1.13",
+    "reflect-metadata": "^0.1.13",
     "rimraf": "^2.6.2",
     "sinon": "~14.0.0",
     "sort-package-json": "~1.53.1",
@@ -78,7 +78,8 @@
     "webpack-cli": "~4.9.2"
   },
   "peerDependencies": {
-    "inversify": "^6.0.1"
+    "inversify": "^6.0.1",
+    "reflect-metadata": "^0.1.13"
   },
   "engines": {
     "node": ">=12.20 <19.0.0"

--- a/storage/core/package.json
+++ b/storage/core/package.json
@@ -55,13 +55,14 @@
     "inversify": "^6.0.1",
     "mocha": "~10.2.0",
     "nyc": "^14.0.0",
-    "reflect-metadata": "~0.1.13",
+    "reflect-metadata": "^0.1.13",
     "rimraf": "^2.6.2",
     "sort-package-json": "~1.53.1",
     "typescript": "^5.1.3"
   },
   "peerDependencies": {
-    "inversify": "^6.0.1"
+    "inversify": "^6.0.1",
+    "reflect-metadata": "^0.1.13"
   },
   "engines": {
     "node": ">=12.20 <19.0.0"

--- a/storage/minio/package.json
+++ b/storage/minio/package.json
@@ -75,7 +75,7 @@
     "mocha": "~10.2.0",
     "npm-run-all": "~4.1.5",
     "nyc": "^14.0.0",
-    "reflect-metadata": "~0.1.13",
+    "reflect-metadata": "^0.1.13",
     "rimraf": "^2.6.2",
     "sinon": "~14.0.0",
     "sort-package-json": "~1.53.1",
@@ -85,7 +85,8 @@
     "webpack-cli": "~4.9.2"
   },
   "peerDependencies": {
-    "inversify": "^6.0.1"
+    "inversify": "^6.0.1",
+    "reflect-metadata": "^0.1.13"
   },
   "engines": {
     "node": ">=12.20 <19.0.0"

--- a/storage/oss/package.json
+++ b/storage/oss/package.json
@@ -64,7 +64,7 @@
     "mocha": "~10.2.0",
     "npm-run-all": "~4.1.5",
     "nyc": "^14.0.0",
-    "reflect-metadata": "~0.1.13",
+    "reflect-metadata": "^0.1.13",
     "rimraf": "^2.6.2",
     "sort-package-json": "~1.53.1",
     "typescript": "^5.1.3",
@@ -73,7 +73,8 @@
     "webpack-cli": "~4.9.2"
   },
   "peerDependencies": {
-    "inversify": "^6.0.1"
+    "inversify": "^6.0.1",
+    "reflect-metadata": "^0.1.13"
   },
   "engines": {
     "node": ">=12.20 <19.0.0"

--- a/storage/s3/package.json
+++ b/storage/s3/package.json
@@ -68,14 +68,15 @@
     "inversify": "^6.0.1",
     "mocha": "~10.2.0",
     "nyc": "^14.0.0",
-    "reflect-metadata": "~0.1.13",
+    "reflect-metadata": "^0.1.13",
     "rimraf": "^2.6.2",
     "sinon": "~14.0.0",
     "sort-package-json": "~1.53.1",
     "typescript": "^5.1.3"
   },
   "peerDependencies": {
-    "inversify": "^6.0.1"
+    "inversify": "^6.0.1",
+    "reflect-metadata": "^0.1.13"
   },
   "engines": {
     "node": ">=12.20 <19.0.0"

--- a/tests/backend-storage/package.json
+++ b/tests/backend-storage/package.json
@@ -46,7 +46,7 @@
     "fs-extra": "~10.1.0",
     "inversify": "^6.0.1",
     "mocha": "~10.2.0",
-    "reflect-metadata": "~0.1.13"
+    "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
     "@itwin/object-storage-common-config": "workspace:*",


### PR DESCRIPTION
In this PR:
- Included  `reflect-metadata` as a peer dependency since package users need to install and import it.