### PR TITLE
Ensure version consistency on publish and dynamically resolve NPM tag  

### DIFF
--- a/common/config/azure-pipelines/build-test-publish.yml
+++ b/common/config/azure-pipelines/build-test-publish.yml
@@ -12,31 +12,31 @@ variables:
 trigger: none
 
 jobs:
-  # - job: BuildAndTest
-  #   strategy:
-  #     matrix:
-  #       linux-node-18:
-  #         imageName: 'ubuntu-latest'
-  #         nodeVersion: $(node18Version)
-  #         runFrontendIntegrationTests: true
-  #       windows-node-18:
-  #         imageName: 'windows-latest'
-  #         nodeVersion: $(node18Version)
-  #         runFrontendIntegrationTests: true
-  #   pool:
-  #       vmImage: $(imageName)
-  #   variables:
-  #     - group: object-storage - Integration Tests Variables
-  #   workspace:
-  #     clean: all
+  - job: BuildAndTest
+    strategy:
+      matrix:
+        linux-node-18:
+          imageName: 'ubuntu-latest'
+          nodeVersion: $(node18Version)
+          runFrontendIntegrationTests: true
+        windows-node-18:
+          imageName: 'windows-latest'
+          nodeVersion: $(node18Version)
+          runFrontendIntegrationTests: true
+    pool:
+        vmImage: $(imageName)
+    variables:
+      - group: object-storage - Integration Tests Variables
+    workspace:
+      clean: all
 
-  #   steps:
-  #   - template: templates/build-test.yml
-  #     parameters:
-  #       runRushAudit: ${{ parameters.runRushAudit }}
+    steps:
+    - template: templates/build-test.yml
+      parameters:
+        runRushAudit: ${{ parameters.runRushAudit }}
 
   - job: Publish
-    # dependsOn: BuildAndTest
+    dependsOn: BuildAndTest
     pool: 
       vmImage: 'windows-latest'
    

--- a/common/config/azure-pipelines/build-test-publish.yml
+++ b/common/config/azure-pipelines/build-test-publish.yml
@@ -12,31 +12,31 @@ variables:
 trigger: none
 
 jobs:
-  - job: BuildAndTest
-    strategy:
-      matrix:
-        linux-node-18:
-          imageName: 'ubuntu-latest'
-          nodeVersion: $(node18Version)
-          runFrontendIntegrationTests: true
-        windows-node-18:
-          imageName: 'windows-latest'
-          nodeVersion: $(node18Version)
-          runFrontendIntegrationTests: true
-    pool:
-        vmImage: $(imageName)
-    variables:
-      - group: object-storage - Integration Tests Variables
-    workspace:
-      clean: all
+  # - job: BuildAndTest
+  #   strategy:
+  #     matrix:
+  #       linux-node-18:
+  #         imageName: 'ubuntu-latest'
+  #         nodeVersion: $(node18Version)
+  #         runFrontendIntegrationTests: true
+  #       windows-node-18:
+  #         imageName: 'windows-latest'
+  #         nodeVersion: $(node18Version)
+  #         runFrontendIntegrationTests: true
+  #   pool:
+  #       vmImage: $(imageName)
+  #   variables:
+  #     - group: object-storage - Integration Tests Variables
+  #   workspace:
+  #     clean: all
 
-    steps:
-    - template: templates/build-test.yml
-      parameters:
-        runRushAudit: ${{ parameters.runRushAudit }}
+  #   steps:
+  #   - template: templates/build-test.yml
+  #     parameters:
+  #       runRushAudit: ${{ parameters.runRushAudit }}
 
   - job: Publish
-    dependsOn: BuildAndTest
+    # dependsOn: BuildAndTest
     pool: 
       vmImage: 'windows-latest'
    

--- a/common/config/azure-pipelines/templates/publish.yml
+++ b/common/config/azure-pipelines/templates/publish.yml
@@ -11,7 +11,26 @@ steps:
   - script: node common/scripts/install-run-rush.js rebuild -v
     displayName: rush rebuild
 
-  - script: node common/scripts/install-run-rush.js publish --publish --include-all --set-access-level public
+  - script: git config --local user.email imodeljs-admin@users.noreply.github.com
+    displayName: Set GitHub user email (needed by `rush version`)
+
+  - script: node common/scripts/install-run-rush.js version --ensure-version-policy
+    displayName: Ensure consistent version across all packages
+    
+  - powershell: |
+      # Get the new dev version number. (Hint this is different than the overall version number used elsewhere)
+      $json = Get-Content -Raw -Path cloud-agnostic/core/package.json | ConvertFrom-Json
+      
+      $newVersion = $json.version
+      $npmTag = If ($newVersion -match "dev") {"nightly"} Else {"latest"}
+      Write-Host "##vso[task.setvariable variable=resolvedNpmTag;]$npmTag"
+
+      Write-Host New version is $newVersion and it will be tagged using $npmTag tag
+    displayName: Resolve version tag
+
+  - script: echo $(resolvedNpmTag)
+
+  - script: node common/scripts/install-run-rush.js publish --publish --include-all --set-access-level public --tag $(resolvedNpmTag)
     displayName: rush publish package
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
     env:

--- a/common/config/azure-pipelines/templates/publish.yml
+++ b/common/config/azure-pipelines/templates/publish.yml
@@ -18,10 +18,8 @@ steps:
     displayName: Ensure consistent version across all packages
     
   - powershell: |
-      # Get the new dev version number. (Hint this is different than the overall version number used elsewhere)
-      $json = Get-Content -Raw -Path cloud-agnostic/core/package.json | ConvertFrom-Json
-      
-      $newVersion = $json.version
+      $cloudAgnosticCorePackageJson = Get-Content -Raw -Path cloud-agnostic/core/package.json | ConvertFrom-Json
+      $newVersion = $cloudAgnosticCorePackageJson.version
       $npmTag = If ($newVersion -match "dev") {"nightly"} Else {"latest"}
       Write-Host "##vso[task.setvariable variable=resolvedNpmTag;]$npmTag"
 

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -1,0 +1,8 @@
+[
+  {
+    "definitionName": "lockStepVersion",
+    "policyName": "lockStepVersionObjectStorage",
+    "version": "2.1.0-dev.1",
+    "nextBump": "prerelease"
+  }
+]

--- a/rush.json
+++ b/rush.json
@@ -15,34 +15,34 @@
     {
       "packageName": "@itwin/cloud-agnostic-core",
       "projectFolder": "cloud-agnostic/core",
-      "shouldPublish": true
+      "versionPolicyName": "lockStepVersionObjectStorage"
     },
     {
       "packageName": "@itwin/object-storage-core",
       "projectFolder": "storage/core",
-      "shouldPublish": true
+      "versionPolicyName": "lockStepVersionObjectStorage"
     },
     {
       "packageName": "@itwin/object-storage-s3",
       "projectFolder": "storage/s3",
-      "shouldPublish": true
+      "versionPolicyName": "lockStepVersionObjectStorage"
     },
     {
       "packageName": "@itwin/object-storage-azure",
       "projectFolder": "storage/azure",
-      "shouldPublish": true,
+      "versionPolicyName": "lockStepVersionObjectStorage",
       "tags": [ "integration-tested" ]
     },
     {
       "packageName": "@itwin/object-storage-minio",
       "projectFolder": "storage/minio",
-      "shouldPublish": true,
+      "versionPolicyName": "lockStepVersionObjectStorage",
       "tags": [ "integration-tested" ]
     },
     {
       "packageName": "@itwin/object-storage-oss",
       "projectFolder": "storage/oss",
-      "shouldPublish": true
+      "versionPolicyName": "lockStepVersionObjectStorage"
     },
     {
       "packageName": "@itwin/object-storage-tests-backend",


### PR DESCRIPTION
In this PR:
- Added a policy to ensure exact same version across published packages
- Added dynamic NPM tag resolution based on package version. If current version is a dev version, the tag is `nightly`, otherwise the tag is `latest.