### PR TITLE
Bump `axios` version to resolve security vulnerability

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -144,7 +144,7 @@ importers:
       '@types/chai-as-promised': ^7.1.2
       '@types/mocha': ~10.0.1
       '@types/node': ^18.11.18
-      axios: ~0.27.2
+      axios: ~1.6.2
       chai: ^4.3.10
       chai-as-promised: ^7.1.1
       cspell: ~5.18.5
@@ -159,7 +159,7 @@ importers:
       typescript: ^5.1.3
     dependencies:
       '@itwin/cloud-agnostic-core': link:../../cloud-agnostic/core
-      axios: 0.27.2
+      axios: 1.6.2
     devDependencies:
       '@itwin/object-storage-common-config': link:../../utils/common-config
       '@types/chai': 4.3.8
@@ -471,7 +471,7 @@ importers:
       '@itwin/object-storage-core': workspace:*
       '@types/express': ~4.17.13
       '@types/node': ^18.11.18
-      axios: ~0.27.2
+      axios: ~1.6.2
       cross-env: ~7.0.3
       cspell: ~5.18.5
       cypress: ^12.13.0
@@ -490,7 +490,7 @@ importers:
       '@itwin/object-storage-common-config': link:../../utils/common-config
       '@types/express': 4.17.17
       '@types/node': 18.11.19
-      axios: 0.27.2
+      axios: 1.6.2
       cross-env: 7.0.3
       cspell: 5.18.5
       eslint: 8.42.0
@@ -4412,11 +4412,12 @@ packages:
       - debug
     dev: true
 
-  /axios/0.27.2:
-    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
+  /axios/1.6.2:
+    resolution: {integrity: sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==}
     dependencies:
       follow-redirects: 1.15.2
       form-data: 4.0.0
+      proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
 
@@ -8421,6 +8422,9 @@ packages:
 
   /proxy-from-env/1.0.0:
     resolution: {integrity: sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==}
+
+  /proxy-from-env/1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   /prr/1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}

--- a/storage/core/package.json
+++ b/storage/core/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@itwin/cloud-agnostic-core": "workspace:*",
-    "axios": "~0.27.2"
+    "axios": "~1.6.2"
   },
   "devDependencies": {
     "@itwin/object-storage-common-config": "workspace:*",

--- a/tests/frontend-storage/package.json
+++ b/tests/frontend-storage/package.json
@@ -47,7 +47,7 @@
     "@itwin/object-storage-common-config": "workspace:*",
     "@types/express": "~4.17.13",
     "@types/node": "^18.11.18",
-    "axios": "~0.27.2",
+    "axios": "~1.6.2",
     "cross-env": "~7.0.3",
     "cspell": "~5.18.5",
     "eslint": "^8.42.0",


### PR DESCRIPTION
In this PR:
- Bumped `axios` version to resolve https://github.com/advisories/GHSA-wf5p-g6vw-rhxx vulnerability