### PR TITLE
Mark inversify and reflect-metadata peerDependencies as optional.

### DIFF
--- a/cloud-agnostic/core/package.json
+++ b/cloud-agnostic/core/package.json
@@ -54,5 +54,13 @@
   "peerDependencies": {
     "inversify": "^6.0.1",
     "reflect-metadata": "^0.1.13"
+  },
+  "peerDependenciesMeta": {
+    "inversify": {
+      "optional": true
+    },
+    "reflect-metadata": {
+      "optional": true
+    }
   }
 }

--- a/storage/azure/package.json
+++ b/storage/azure/package.json
@@ -82,5 +82,13 @@
   "peerDependencies": {
     "inversify": "^6.0.1",
     "reflect-metadata": "^0.1.13"
+  },
+  "peerDependenciesMeta": {
+    "inversify": {
+      "optional": true
+    },
+    "reflect-metadata": {
+      "optional": true
+    }
   }
 }

--- a/storage/core/package.json
+++ b/storage/core/package.json
@@ -63,5 +63,13 @@
   "peerDependencies": {
     "inversify": "^6.0.1",
     "reflect-metadata": "^0.1.13"
+  },
+  "peerDependenciesMeta": {
+    "inversify": {
+      "optional": true
+    },
+    "reflect-metadata": {
+      "optional": true
+    }
   }
 }

--- a/storage/minio/package.json
+++ b/storage/minio/package.json
@@ -88,5 +88,13 @@
   "peerDependencies": {
     "inversify": "^6.0.1",
     "reflect-metadata": "^0.1.13"
+  },
+  "peerDependenciesMeta": {
+    "inversify": {
+      "optional": true
+    },
+    "reflect-metadata": {
+      "optional": true
+    }
   }
 }

--- a/storage/oss/package.json
+++ b/storage/oss/package.json
@@ -77,5 +77,13 @@
   "peerDependencies": {
     "inversify": "^6.0.1",
     "reflect-metadata": "^0.1.13"
+  },
+  "peerDependenciesMeta": {
+    "inversify": {
+      "optional": true
+    },
+    "reflect-metadata": {
+      "optional": true
+    }
   }
 }

--- a/storage/s3/package.json
+++ b/storage/s3/package.json
@@ -77,5 +77,13 @@
   "peerDependencies": {
     "inversify": "^6.0.1",
     "reflect-metadata": "^0.1.13"
+  },
+  "peerDependenciesMeta": {
+    "inversify": {
+      "optional": true
+    },
+    "reflect-metadata": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
Given that these packages are useable without inversify, we should use the [peerDependenciesMeta](https://pnpm.io/package_json#peerdependenciesmeta) package.json field to suppress missing peer errors from pnpm.

These errors are [currently adding](https://dev.azure.com/imodeljs/imodeljs/_build/results?buildId=9214&view=logs&j=679d485c-ead4-51e4-2fdd-4f4349f63c52&t=3d715f0c-ef23-5ec9-f612-8a4965cc441e&l=251) a lot of noise when running `rush install` in the itwinjs-core repo.