### PR TITLE
Di rework

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,8 @@
     "**/node_modules": true,
     "**/out": true,
     "**/lib": true,
+    "**/cypress": true,
+    "**/dist": true,
     "common/temp": true
   },
   "eslint.workingDirectories": [

--- a/cloud-agnostic/core/src/Bindable.ts
+++ b/cloud-agnostic/core/src/Bindable.ts
@@ -2,11 +2,11 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Container } from "inversify";
 
 import { Dependency } from "./Dependency";
 import { DependenciesConfig, DependencyConfig } from "./DependencyConfig";
 import { DependencyFactory } from "./DependencyFactory";
+import { DIContainer } from "./DIContainer";
 import { DependencyError } from "./internal";
 import { Types } from "./Types";
 
@@ -34,7 +34,7 @@ export abstract class Bindable {
   }
 
   private bindNamedDependencies(
-    container: Container,
+    container: DIContainer,
     factory: DependencyFactory,
     configs: DependencyConfig[]
   ): void {
@@ -46,15 +46,17 @@ export abstract class Bindable {
   }
 
   private bindDependency(
-    container: Container,
+    container: DIContainer,
     factory: DependencyFactory,
     config: DependencyConfig
   ) {
     factory.getDependency(config.dependencyName).register(container, config);
   }
 
-  protected bindDependencies(container: Container): void {
-    const config = container.get<DependenciesConfig>(Types.dependenciesConfig);
+  protected bindDependencies(container: DIContainer): void {
+    const config = container.resolve<DependenciesConfig>(
+      Types.dependenciesConfig
+    );
 
     this._dependencyFactories.forEach((factory) => {
       const dependencyConfig = config[factory.dependencyType];

--- a/cloud-agnostic/core/src/DIContainer.ts
+++ b/cloud-agnostic/core/src/DIContainer.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { DIIdentifier } from "./internal";
 

--- a/cloud-agnostic/core/src/DIContainer.ts
+++ b/cloud-agnostic/core/src/DIContainer.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { DIIdentifier } from "./internal";
+
+export abstract class DIContainer {
+  abstract registerFactory<T>(
+    key: DIIdentifier<T>,
+    factory: (container: DIContainer) => T
+  ): void;
+
+  abstract registerNamedFactory<T>(
+    key: DIIdentifier<T>,
+    factory: (container: DIContainer) => T,
+    name: string
+  ): void;
+
+  abstract registerInstance<T>(key: DIIdentifier<T>, instance: T): void;
+
+  abstract unregister<T>(key: DIIdentifier<T>): void;
+
+  abstract resolve<T>(key: DIIdentifier<T>): T;
+
+  abstract resolveNamed<T>(key: DIIdentifier<T>, name: string): T;
+
+  abstract resolveAll<T>(key: DIIdentifier<T>): T[];
+
+  abstract createChild(): DIContainer;
+}

--- a/cloud-agnostic/core/src/Dependency.ts
+++ b/cloud-agnostic/core/src/Dependency.ts
@@ -2,15 +2,15 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Container } from "inversify";
 
 import { DependencyConfig } from "./DependencyConfig";
+import { DIContainer } from "./DIContainer";
 
 export abstract class Dependency {
   public abstract dependencyName: string;
   public abstract dependencyType: string;
   public abstract register(
-    container: Container,
+    container: DIContainer,
     config?: DependencyConfig
   ): void;
 }

--- a/cloud-agnostic/core/src/index.ts
+++ b/cloud-agnostic/core/src/index.ts
@@ -2,6 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+
+export * from "./DIContainer";
 export * from "./Bindable";
 export * from "./Dependency";
 export * from "./NamedDependency";

--- a/cloud-agnostic/core/src/internal/Types.ts
+++ b/cloud-agnostic/core/src/internal/Types.ts
@@ -2,6 +2,11 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-export * from "./Errors";
-export * from "./Helpers";
-export * from "./Types";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Constructor<T> = new (...args: any[]) => T;
+export interface Abstract<T> {
+  prototype: T;
+}
+
+export type DIIdentifier<T> = symbol | Constructor<T> | Abstract<T>;

--- a/cloud-agnostic/core/src/inversify/InversifyWrapper.ts
+++ b/cloud-agnostic/core/src/inversify/InversifyWrapper.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import "reflect-metadata";
 
 import { Container, decorate, injectable, METADATA_KEY } from "inversify";

--- a/cloud-agnostic/core/src/inversify/InversifyWrapper.ts
+++ b/cloud-agnostic/core/src/inversify/InversifyWrapper.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import "reflect-metadata";
+
+import { Container, decorate, injectable, METADATA_KEY } from "inversify";
+
+import { DIContainer } from "../DIContainer";
+import { Abstract, Constructor, DIIdentifier } from "../internal";
+
+export class InversifyWrapper extends DIContainer {
+  constructor(private _container: Container) {
+    super();
+  }
+
+  public static create(): DIContainer {
+    return new InversifyWrapper(new Container());
+  }
+
+  private needsDecoration<T>(
+    key: DIIdentifier<T>
+  ): key is Constructor<T> | Abstract<T> {
+    if (typeof key === "symbol") return false;
+    return Reflect.hasOwnMetadata(METADATA_KEY.PARAM_TYPES, key);
+  }
+
+  public override registerFactory<T>(
+    key: DIIdentifier<T>,
+    factory: (container: DIContainer) => T
+  ): void {
+    if (this.needsDecoration(key)) {
+      decorate(injectable(), key);
+    }
+
+    this._container
+      .bind<T>(key)
+      .toDynamicValue(() => factory(this))
+      .inSingletonScope();
+  }
+
+  public override registerNamedFactory<T>(
+    key: DIIdentifier<T>,
+    factory: (container: DIContainer) => T,
+    name: string
+  ): void {
+    if (this.needsDecoration(key)) {
+      decorate(injectable(), key);
+    }
+
+    this._container
+      .bind<T>(key)
+      .toDynamicValue(() => factory(this))
+      .whenTargetNamed(name);
+  }
+
+  public override registerInstance<T>(key: DIIdentifier<T>, instance: T): void {
+    this._container.bind<T>(key).toConstantValue(instance);
+  }
+
+  public override unregister<T>(key: DIIdentifier<T>): void {
+    this._container.unbind(key);
+  }
+
+  public override resolve<T>(key: DIIdentifier<T>): T {
+    return this._container.get<T>(key);
+  }
+
+  public override resolveNamed<T>(key: DIIdentifier<T>, name: string): T {
+    return this._container.getNamed<T>(key, name);
+  }
+
+  public override resolveAll<T>(key: DIIdentifier<T>): T[] {
+    return this._container.getAll<T>(key);
+  }
+
+  public override createChild(): DIContainer {
+    return new InversifyWrapper(this._container.createChild());
+  }
+}

--- a/cloud-agnostic/core/src/inversify/index.ts
+++ b/cloud-agnostic/core/src/inversify/index.ts
@@ -2,6 +2,4 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-export * from "./Errors";
-export * from "./Helpers";
-export * from "./Types";
+export * from "./InversifyWrapper";

--- a/cloud-agnostic/core/src/test/Bindable.test.ts
+++ b/cloud-agnostic/core/src/test/Bindable.test.ts
@@ -3,10 +3,10 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
-import { Container } from "inversify";
 
 import { Bindable, DependenciesConfig, NamedInstance } from "..";
 import { DependencyError, DependencyTypeError } from "../internal";
+import { InversifyWrapper } from "../inversify";
 
 import { ConcreteTest, Test, TestConfig } from "./Test";
 import { ConcreteTestDependencyBindings } from "./TestDependency";
@@ -63,17 +63,20 @@ function validateTestObject(test: Test, config: TestConfig) {
 
 describe(`${Bindable.name}`, () => {
   it(`should resolve registered dependency`, () => {
-    const setup = new TestSetup(new Container(), dependenciesConfig);
+    const setup = new TestSetup(InversifyWrapper.create(), dependenciesConfig);
 
     setup.start();
 
-    const test = setup.container.get(Test);
+    const test = setup.container.resolve(Test);
     expect(test instanceof ConcreteTest).to.be.true;
     expect(test.property === "testProperty").to.be.true;
   });
 
   it(`should throw if dependency factory is not registered`, () => {
-    const setup = new TestSetupNoFactory(new Container(), dependenciesConfig);
+    const setup = new TestSetupNoFactory(
+      InversifyWrapper.create(),
+      dependenciesConfig
+    );
 
     const testedFunction = () =>
       setup.useBindings(ConcreteTestDependencyBindings);
@@ -87,7 +90,7 @@ describe(`${Bindable.name}`, () => {
 
   it(`should throw if testName dependency is not registered`, () => {
     const setup = new TestSetupNoDefaultDependencies(
-      new Container(),
+      InversifyWrapper.create(),
       dependenciesConfig
     );
 
@@ -102,7 +105,7 @@ describe(`${Bindable.name}`, () => {
 
   it(`should throw if testName does not support named dependency instances`, () => {
     const setup = new TestSetup(
-      new Container(),
+      InversifyWrapper.create(),
       dependenciesConfigWithMultipleInstances
     );
 
@@ -117,29 +120,29 @@ describe(`${Bindable.name}`, () => {
 
   it(`should resolve registered named dependency instance`, () => {
     const setup = new TestSetupWithNamedInstances(
-      new Container(),
+      InversifyWrapper.create(),
       dependenciesConfigWithOneInstance
     );
 
     setup.start();
 
-    const test = setup.container.getNamed(Test, "instanceName");
+    const test = setup.container.resolveNamed(Test, "instanceName");
     validateTestObject(test, testConfigWithOneInstance[0]);
   });
 
   it(`should resolve multiple registered named dependency instances by name`, () => {
     const setup = new TestSetupWithNamedInstances(
-      new Container(),
+      InversifyWrapper.create(),
       dependenciesConfigWithMultipleInstances
     );
 
     setup.start();
 
-    const test = setup.container.getNamed(
+    const test = setup.container.resolveNamed(
       Test,
       testConfigWithMultipleInstances[0].instanceName!
     );
-    const test2 = setup.container.getNamed(
+    const test2 = setup.container.resolveNamed(
       Test,
       testConfigWithMultipleInstances[1].instanceName!
     );
@@ -150,13 +153,13 @@ describe(`${Bindable.name}`, () => {
 
   it(`should resolve multiple registered named dependency instances as array`, () => {
     const setup = new TestSetupWithNamedInstances(
-      new Container(),
+      InversifyWrapper.create(),
       dependenciesConfigWithMultipleInstances
     );
 
     setup.start();
 
-    const tests: NamedInstance<Test>[] = setup.container.getAll(
+    const tests: NamedInstance<Test>[] = setup.container.resolveAll(
       NamedInstance<Test>
     );
 

--- a/cloud-agnostic/core/src/test/Test.ts
+++ b/cloud-agnostic/core/src/test/Test.ts
@@ -2,9 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
-import { inject, injectable } from "inversify";
 
 import { DependencyConfig } from "..";
 
@@ -14,18 +11,13 @@ export interface TestConfig extends DependencyConfig {
 
 export const testConfigType = Symbol.for("TestConfig");
 
-@injectable()
 export abstract class Test {
   abstract get property(): string;
   abstract get instanceName(): string | undefined;
 }
 
-@injectable()
 export class ConcreteTest extends Test {
-  constructor(
-    @inject(testConfigType)
-    private _config: TestConfig
-  ) {
+  constructor(private _config: TestConfig) {
     super();
   }
 

--- a/cloud-agnostic/core/src/test/TestDependency.ts
+++ b/cloud-agnostic/core/src/test/TestDependency.ts
@@ -2,10 +2,10 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Container } from "inversify";
 
 import { Bindable, Dependency } from "..";
 import { DependencyConfig } from "../DependencyConfig";
+import { DIContainer } from "../DIContainer";
 import { ConfigError } from "../internal";
 import { NamedDependency } from "../NamedDependency";
 
@@ -24,22 +24,30 @@ export abstract class TestNamedDependency extends NamedDependency {
 export class ConcreteTestDependencyBindings extends TestDependency {
   public readonly dependencyName = "testName";
 
-  public register(container: Container, config: TestConfig): void {
-    container.bind<TestConfig>(testConfigType).toDynamicValue(() => config);
-    container.bind(Test).to(ConcreteTest).inSingletonScope();
+  public register(container: DIContainer, config: TestConfig): void {
+    container.registerInstance<TestConfig>(testConfigType, config);
+    container.registerFactory<Test>(
+      Test,
+      (c: DIContainer) =>
+        new ConcreteTest(c.resolve<TestConfig>(testConfigType))
+    );
   }
 }
 export class ConcreteTestDependencyBindingsWithInstances extends TestNamedDependency {
   public readonly dependencyName = "testName";
 
-  public register(container: Container, config: TestConfig): void {
-    container.bind<TestConfig>(testConfigType).toDynamicValue(() => config);
-    container.bind(Test).to(ConcreteTest).inSingletonScope();
+  public register(container: DIContainer, config: TestConfig): void {
+    container.registerInstance<TestConfig>(testConfigType, config);
+    container.registerFactory<Test>(
+      Test,
+      (c: DIContainer) =>
+        new ConcreteTest(c.resolve<TestConfig>(testConfigType))
+    );
   }
 
   protected override _registerInstance(
-    container: Container,
-    childContainer: Container,
+    container: DIContainer,
+    childContainer: DIContainer,
     config: DependencyConfig
   ): void {
     if (!config.instanceName)

--- a/cloud-agnostic/core/src/test/TestSetup.ts
+++ b/cloud-agnostic/core/src/test/TestSetup.ts
@@ -2,9 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Container } from "inversify";
 
 import { Bindable, DependenciesConfig, Types } from "..";
+import { DIContainer } from "../DIContainer";
 
 import {
   DefaultTestDependencies,
@@ -13,15 +13,16 @@ import {
 } from "./TestDependency";
 
 export class TestSetup extends Bindable {
-  constructor(public container: Container, config: DependenciesConfig) {
+  constructor(public container: DIContainer, config: DependenciesConfig) {
     super();
 
     this.requireDependency(TestDependency.dependencyType);
     DefaultTestDependencies.apply(this);
 
-    container
-      .bind<DependenciesConfig>(Types.dependenciesConfig)
-      .toDynamicValue(() => config);
+    this.container.registerInstance<DependenciesConfig>(
+      Types.dependenciesConfig,
+      config
+    );
   }
 
   public start(): void {
@@ -30,15 +31,16 @@ export class TestSetup extends Bindable {
 }
 
 export class TestSetupWithNamedInstances extends Bindable {
-  constructor(public container: Container, config: DependenciesConfig) {
+  constructor(public container: DIContainer, config: DependenciesConfig) {
     super();
 
     this.requireDependency(TestDependency.dependencyType);
     DefaultTestDependenciesWithInstances.apply(this);
 
-    container
-      .bind<DependenciesConfig>(Types.dependenciesConfig)
-      .toDynamicValue(() => config);
+    container.registerInstance<DependenciesConfig>(
+      Types.dependenciesConfig,
+      config
+    );
   }
 
   public start(): void {
@@ -47,12 +49,13 @@ export class TestSetupWithNamedInstances extends Bindable {
 }
 
 export class TestSetupNoFactory extends Bindable {
-  constructor(public container: Container, config: DependenciesConfig) {
+  constructor(public container: DIContainer, config: DependenciesConfig) {
     super();
 
-    container
-      .bind<DependenciesConfig>(Types.dependenciesConfig)
-      .toDynamicValue(() => config);
+    container.registerInstance<DependenciesConfig>(
+      Types.dependenciesConfig,
+      config
+    );
   }
 
   public start(): void {
@@ -61,14 +64,15 @@ export class TestSetupNoFactory extends Bindable {
 }
 
 export class TestSetupNoDefaultDependencies extends Bindable {
-  constructor(public container: Container, config: DependenciesConfig) {
+  constructor(public container: DIContainer, config: DependenciesConfig) {
     super();
 
     this.requireDependency(TestDependency.dependencyType);
 
-    container
-      .bind<DependenciesConfig>(Types.dependenciesConfig)
-      .toDynamicValue(() => config);
+    container.registerInstance<DependenciesConfig>(
+      Types.dependenciesConfig,
+      config
+    );
   }
 
   public start(): void {

--- a/samples/src/client-file-download/FileDownloader.ts
+++ b/samples/src/client-file-download/FileDownloader.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { injectable } from "inversify";
 
 import { ClientStorage } from "@itwin/object-storage-core";
 
@@ -11,7 +10,6 @@ import { ClientStorage } from "@itwin/object-storage-core";
  * implementation of {@link ClientStorage} can be passed to the constructor
  * making this class cloud agnostic.
  */
-@injectable()
 export class FileDownloader {
   constructor(private _storage: ClientStorage) {}
 

--- a/samples/src/client-file-download/NamedFileDownloader.ts
+++ b/samples/src/client-file-download/NamedFileDownloader.ts
@@ -3,8 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { inject, injectable, named } from "inversify";
-
 import { ClientStorage } from "@itwin/object-storage-core";
 
 /**
@@ -13,14 +11,9 @@ import { ClientStorage } from "@itwin/object-storage-core";
  * making this class cloud agnostic. {@link ClientStorage} instances are resolved
  * using instance name (which is described in the configuration as instanceName property)
  */
-@injectable()
 export class NamedFileDownloader {
   constructor(
-    @inject(ClientStorage)
-    @named("instanceName1")
     private _storage1: ClientStorage,
-    @inject(ClientStorage)
-    @named("instanceName2")
     private _storage2: ClientStorage
   ) {}
 

--- a/samples/src/client-file-download/with-inversify/Run.ts
+++ b/samples/src/client-file-download/with-inversify/Run.ts
@@ -21,13 +21,14 @@ import { App } from "./App";
 async function run(): Promise<void> {
   const app = new App();
 
-  app.container
-    .bind<DependenciesConfig>(DependencyTypes.dependenciesConfig)
-    .toConstantValue({
+  app.container.registerInstance<DependenciesConfig>(
+    DependencyTypes.dependenciesConfig,
+    {
       ClientStorage: {
         dependencyName: "azure",
       },
-    });
+    }
+  );
   app.useBindings(AzureClientStorageBindings);
 
   return app.start();

--- a/samples/src/client-file-download/with-named-instances/Run.ts
+++ b/samples/src/client-file-download/with-named-instances/Run.ts
@@ -21,9 +21,9 @@ import { App } from "./App";
 async function run(): Promise<void> {
   const app = new App();
 
-  app.container
-    .bind<DependenciesConfig>(DependencyTypes.dependenciesConfig)
-    .toConstantValue({
+  app.container.registerInstance<DependenciesConfig>(
+    DependencyTypes.dependenciesConfig,
+    {
       ClientStorage: [
         {
           instanceName: "instanceName1",
@@ -34,7 +34,8 @@ async function run(): Promise<void> {
           dependencyName: "azure",
         },
       ],
-    });
+    }
+  );
   app.useBindings(AzureClientStorageBindings);
 
   return app.start();

--- a/storage/azure/src/client/AzureClientStorage.ts
+++ b/storage/azure/src/client/AzureClientStorage.ts
@@ -7,7 +7,6 @@ import { dirname } from "path";
 import { Readable } from "stream";
 
 import { BlobDownloadOptions } from "@azure/storage-blob";
-import { inject, injectable } from "inversify";
 
 import { assertRelativeDirectory } from "@itwin/object-storage-core/lib/common/internal";
 import {
@@ -19,7 +18,6 @@ import {
 import {
   ClientStorage,
   TransferData,
-  Types,
   UrlDownloadInput,
   UrlUploadInput,
 } from "@itwin/object-storage-core";
@@ -31,12 +29,8 @@ import {
 } from "../server";
 import { BlockBlobClientWrapperFactory } from "../server/wrappers";
 
-@injectable()
 export class AzureClientStorage extends ClientStorage {
-  constructor(
-    @inject(Types.Client.clientWrapperFactory)
-    private _clientWrapperFactory: BlockBlobClientWrapperFactory
-  ) {
+  constructor(private _clientWrapperFactory: BlockBlobClientWrapperFactory) {
     super();
   }
 

--- a/storage/azure/src/client/AzureClientStorageBindings.ts
+++ b/storage/azure/src/client/AzureClientStorageBindings.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Container } from "inversify";
 
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 import {
   ClientStorage,
   ClientStorageDependency,
@@ -17,11 +17,15 @@ import { AzureClientStorage } from "./AzureClientStorage";
 export class AzureClientStorageBindings extends ClientStorageDependency {
   public readonly dependencyName: string = "azure";
 
-  public override register(container: Container): void {
-    container
-      .bind(Types.Client.clientWrapperFactory)
-      .to(BlockBlobClientWrapperFactory)
-      .inSingletonScope();
-    container.bind(ClientStorage).to(AzureClientStorage).inSingletonScope();
+  public override register(container: DIContainer): void {
+    container.registerFactory(
+      Types.Client.clientWrapperFactory,
+      () => new BlockBlobClientWrapperFactory()
+    );
+    container.registerFactory(
+      ClientStorage,
+      (c: DIContainer) =>
+        new AzureClientStorage(c.resolve(Types.Client.clientWrapperFactory))
+    );
   }
 }

--- a/storage/azure/src/frontend/AzureFrontendStorage.ts
+++ b/storage/azure/src/frontend/AzureFrontendStorage.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { inject, injectable } from "inversify";
 
 import { assertRelativeDirectory } from "@itwin/object-storage-core/lib/common/internal";
 import {
@@ -10,7 +9,6 @@ import {
   FrontendTransferData,
   FrontendUrlDownloadInput,
   FrontendUrlUploadInput,
-  Types,
 } from "@itwin/object-storage-core/lib/frontend";
 
 import {
@@ -20,10 +18,8 @@ import {
 } from "./FrontendInterfaces";
 import { FrontendBlockBlobClientWrapperFactory } from "./wrappers";
 
-@injectable()
 export class AzureFrontendStorage extends FrontendStorage {
   constructor(
-    @inject(Types.Frontend.clientWrapperFactory)
     private _clientWrapperFactory: FrontendBlockBlobClientWrapperFactory
   ) {
     super();

--- a/storage/azure/src/frontend/AzureFrontendStorageBindings.ts
+++ b/storage/azure/src/frontend/AzureFrontendStorageBindings.ts
@@ -2,13 +2,13 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Container } from "inversify";
-
 import {
   FrontendStorage,
   FrontendStorageDependency,
   Types,
 } from "@itwin/object-storage-core/lib/frontend";
+
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 
 import { AzureFrontendStorage } from "./AzureFrontendStorage";
 import { FrontendBlockBlobClientWrapperFactory } from "./wrappers";
@@ -16,11 +16,15 @@ import { FrontendBlockBlobClientWrapperFactory } from "./wrappers";
 export class AzureFrontendStorageBindings extends FrontendStorageDependency {
   public readonly dependencyName: string = "azure";
 
-  public override register(container: Container): void {
-    container
-      .bind(Types.Frontend.clientWrapperFactory)
-      .to(FrontendBlockBlobClientWrapperFactory)
-      .inSingletonScope();
-    container.bind(FrontendStorage).to(AzureFrontendStorage).inSingletonScope();
+  public override register(container: DIContainer): void {
+    container.registerFactory<FrontendBlockBlobClientWrapperFactory>(
+      Types.Frontend.clientWrapperFactory,
+      () => new FrontendBlockBlobClientWrapperFactory()
+    );
+    container.registerFactory(FrontendStorage, (c: DIContainer) => {
+      return new AzureFrontendStorage(
+        c.resolve(Types.Frontend.clientWrapperFactory)
+      );
+    });
   }
 }

--- a/storage/azure/src/frontend/wrappers/FrontendBlockBlobClientWrapperFactory.ts
+++ b/storage/azure/src/frontend/wrappers/FrontendBlockBlobClientWrapperFactory.ts
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { BlockBlobClient } from "@azure/storage-blob";
-import { injectable } from "inversify";
 
 import { instanceOfUrlTransferInput } from "@itwin/object-storage-core/lib/common/internal";
 import { UrlTransferInput } from "@itwin/object-storage-core/lib/frontend";
@@ -13,7 +12,6 @@ import { buildBlobUrl } from "../../common/internal";
 
 import { FrontendBlockBlobClientWrapper } from "./FrontendBlockBlobClientWrapper";
 
-@injectable()
 export class FrontendBlockBlobClientWrapperFactory {
   public create(
     input: UrlTransferInput | AzureTransferConfigInput

--- a/storage/azure/src/server/AzureServerStorage.ts
+++ b/storage/azure/src/server/AzureServerStorage.ts
@@ -7,7 +7,6 @@ import { dirname } from "path";
 import { Readable } from "stream";
 
 import { RestError } from "@azure/storage-blob";
-import { inject, injectable } from "inversify";
 
 import { assertRelativeDirectory } from "@itwin/object-storage-core/lib/common/internal";
 import {
@@ -33,7 +32,7 @@ import {
   TransferType,
 } from "@itwin/object-storage-core";
 
-import { AzureTransferConfig, Types } from "../common";
+import { AzureTransferConfig } from "../common";
 import { buildBlobName } from "../common/internal";
 
 import {
@@ -48,14 +47,12 @@ export interface AzureServerStorageConfig {
   baseUrl: string;
 }
 
-@injectable()
 export class AzureServerStorage extends ServerStorage {
   private readonly _config: AzureServerStorageConfig;
   private readonly _client: BlobServiceClientWrapper;
 
   public constructor(
-    // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
-    @inject(Types.AzureServer.config) config: AzureServerStorageConfig,
+    config: AzureServerStorageConfig,
     client: BlobServiceClientWrapper
   ) {
     super();

--- a/storage/azure/src/server/wrappers/BlobServiceClientWrapper.ts
+++ b/storage/azure/src/server/wrappers/BlobServiceClientWrapper.ts
@@ -10,7 +10,6 @@ import {
   ContainerClient,
   ContainerItem,
 } from "@azure/storage-blob";
-import { injectable } from "inversify";
 
 import {
   buildObjectKey,
@@ -25,7 +24,6 @@ import {
 
 import { buildBlobName } from "../../common/internal";
 
-@injectable()
 export class BlobServiceClientWrapper {
   private readonly _client: BlobServiceClient;
 

--- a/storage/azure/src/server/wrappers/BlockBlobClientWrapperFactory.ts
+++ b/storage/azure/src/server/wrappers/BlockBlobClientWrapperFactory.ts
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { BlockBlobClient } from "@azure/storage-blob";
-import { injectable } from "inversify";
 
 import { instanceOfUrlTransferInput } from "@itwin/object-storage-core/lib/common/internal";
 
@@ -14,7 +13,6 @@ import { buildBlobUrl } from "../../common/internal";
 
 import { BlockBlobClientWrapper } from "./BlockBlobClientWrapper";
 
-@injectable()
 export class BlockBlobClientWrapperFactory {
   public create(
     input: UrlTransferInput | AzureTransferConfigInput

--- a/storage/azure/src/test/integration/backend/AzureServerStorage.test.ts
+++ b/storage/azure/src/test/integration/backend/AzureServerStorage.test.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import {
   BlobClient,
   BlobServiceClient,

--- a/storage/azure/src/test/integration/backend/RunIntegrationTests.ts
+++ b/storage/azure/src/test/integration/backend/RunIntegrationTests.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import { StorageIntegrationTests } from "@itwin/object-storage-tests-backend";
 
 import { AzureClientStorageBindings } from "../../../client";

--- a/storage/azure/src/test/integration/frontend/AzureFrontendTestSetup.ts
+++ b/storage/azure/src/test/integration/frontend/AzureFrontendTestSetup.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import { FrontendStorageTestSetup } from "@itwin/object-storage-tests-frontend/lib/FrontendStorageTestSetup";
 
 import { AzureFrontendStorageBindings } from "../../../frontend";

--- a/storage/azure/src/test/integration/frontend/RunIntegrationTests.ts
+++ b/storage/azure/src/test/integration/frontend/RunIntegrationTests.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import * as path from "path";
 
 import { FrontendStorageIntegrationTests } from "@itwin/object-storage-tests-frontend";

--- a/storage/azure/src/test/integration/frontend/StartServer.ts
+++ b/storage/azure/src/test/integration/frontend/StartServer.ts
@@ -16,15 +16,16 @@ import { ServerStorageConfigProvider } from "../ServerStorageConfigProvider";
 function run(): void {
   const backendServer = new ServerStorageProxy();
 
-  backendServer.container
-    .bind<DependenciesConfig>(DependencyTypes.dependenciesConfig)
-    .toConstantValue({
+  backendServer.container.registerInstance<DependenciesConfig>(
+    DependencyTypes.dependenciesConfig,
+    {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       ServerStorage: {
         dependencyName: "azure",
         ...new ServerStorageConfigProvider().get(),
       },
-    });
+    }
+  );
   backendServer.useBindings(AzureServerStorageBindings);
   backendServer.start({ port: 1221 });
 }

--- a/storage/azure/src/test/integration/frontend/StartServer.ts
+++ b/storage/azure/src/test/integration/frontend/StartServer.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import {
   DependenciesConfig,
   Types as DependencyTypes,

--- a/storage/azure/src/test/unit/backend/AzureClientStorageBindings.test.ts
+++ b/storage/azure/src/test/unit/backend/AzureClientStorageBindings.test.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import "reflect-metadata";
 
-import { Container } from "inversify";
-
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 import { ClientStorage, Types } from "@itwin/object-storage-core";
 import {
   DependencyBindingsTestCase,
@@ -25,13 +24,13 @@ describe(`${AzureClientStorageBindings.name}`, () => {
     const bindingsTestCases: DependencyBindingsTestCase[] = [
       {
         testedClassIdentifier: ClientStorage.name,
-        testedFunction: (container: Container) => container.get(ClientStorage),
+        testedFunction: (c: DIContainer) => c.resolve(ClientStorage),
         expectedCtor: AzureClientStorage,
       },
       {
         testedClassIdentifier: Types.Client.clientWrapperFactory.toString(),
-        testedFunction: (container: Container) =>
-          container.get<BlockBlobClientWrapperFactory>(
+        testedFunction: (c: DIContainer) =>
+          c.resolve<BlockBlobClientWrapperFactory>(
             Types.Client.clientWrapperFactory
           ),
         expectedCtor: BlockBlobClientWrapperFactory,

--- a/storage/azure/src/test/unit/backend/AzureClientStorageBindings.test.ts
+++ b/storage/azure/src/test/unit/backend/AzureClientStorageBindings.test.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import { DIContainer } from "@itwin/cloud-agnostic-core";
 import { ClientStorage, Types } from "@itwin/object-storage-core";
 import {

--- a/storage/azure/src/test/unit/backend/AzureServerStorageBindings.test.ts
+++ b/storage/azure/src/test/unit/backend/AzureServerStorageBindings.test.ts
@@ -3,8 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { BlobServiceClient } from "@azure/storage-blob";
-import { Container } from "inversify";
 
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 import { ServerStorage } from "@itwin/object-storage-core";
 import {
   DependencyBindingsTestCase,
@@ -61,25 +61,23 @@ describe(`${AzureServerStorageBindings.name}`, () => {
     [
       {
         testedClassIdentifier: ServerStorage.name,
-        testedFunction: (container: Container) => container.get(ServerStorage),
+        testedFunction: (c: DIContainer) => c.resolve(ServerStorage),
         expectedCtor: AzureServerStorage,
       },
       {
         testedClassIdentifier: Types.AzureServer.config.toString(),
-        testedFunction: (container: Container) =>
-          container.get<AzureServerStorageConfig>(Types.AzureServer.config),
+        testedFunction: (c: DIContainer) =>
+          c.resolve<AzureServerStorageConfig>(Types.AzureServer.config),
         expectedCtor: Object,
       },
       {
         testedClassIdentifier: BlobServiceClientWrapper.name,
-        testedFunction: (container: Container) =>
-          container.get(BlobServiceClientWrapper),
+        testedFunction: (c: DIContainer) => c.resolve(BlobServiceClientWrapper),
         expectedCtor: BlobServiceClientWrapper,
       },
       {
         testedClassIdentifier: BlobServiceClient.name,
-        testedFunction: (container: Container) =>
-          container.get(BlobServiceClient),
+        testedFunction: (c: DIContainer) => c.resolve(BlobServiceClient),
         expectedCtor: BlobServiceClient,
       },
     ];

--- a/storage/azure/src/test/unit/backend/RunCommonUnitTests.ts
+++ b/storage/azure/src/test/unit/backend/RunCommonUnitTests.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import { BlobServiceClient } from "@azure/storage-blob";
 import { createStubInstance } from "sinon";
 

--- a/storage/azure/src/test/unit/backend/RunCommonUnitTests.ts
+++ b/storage/azure/src/test/unit/backend/RunCommonUnitTests.ts
@@ -5,9 +5,9 @@
 import "reflect-metadata";
 
 import { BlobServiceClient } from "@azure/storage-blob";
-import { Container } from "inversify";
 import { createStubInstance } from "sinon";
 
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 import { Types } from "@itwin/object-storage-core";
 import { StorageUnitTests } from "@itwin/object-storage-tests-backend-unit";
 
@@ -40,7 +40,7 @@ const azureTestConfig = {
 
 class TestAzureServerStorageBindings extends AzureServerStorageBindings {
   public override register(
-    container: Container,
+    container: DIContainer,
     config: AzureServerStorageBindingsConfig
   ): void {
     super.register(container, config);
@@ -50,24 +50,28 @@ class TestAzureServerStorageBindings extends AzureServerStorageBindings {
       BlobServiceClientWrapper
     );
 
-    container.bind(BlobServiceClient).toConstantValue(mockBlobServiceClient);
-    container
-      .rebind(BlobServiceClientWrapper)
-      .toConstantValue(mockBlobServiceClientWrapper);
+    container.registerInstance(BlobServiceClient, mockBlobServiceClient);
+    container.unregister(BlobServiceClientWrapper);
+    container.registerInstance(
+      BlobServiceClientWrapper,
+      mockBlobServiceClientWrapper
+    );
   }
 }
 
 class TestAzureClientStorageBindings extends AzureClientStorageBindings {
-  public override register(container: Container): void {
+  public override register(container: DIContainer): void {
     super.register(container);
 
     const mockBlockBlobClientWrapperFactory = createStubInstance(
       BlockBlobClientWrapperFactory
     );
 
-    container
-      .rebind(Types.Client.clientWrapperFactory)
-      .toConstantValue(mockBlockBlobClientWrapperFactory);
+    container.unregister(Types.Client.clientWrapperFactory);
+    container.registerInstance(
+      Types.Client.clientWrapperFactory,
+      mockBlockBlobClientWrapperFactory
+    );
   }
 }
 

--- a/storage/azure/src/test/unit/frontend/AzureFrontendStorageBindings.test.ts
+++ b/storage/azure/src/test/unit/frontend/AzureFrontendStorageBindings.test.ts
@@ -2,9 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
-import { Container } from "inversify";
 
 import {
   FrontendStorage,
@@ -14,6 +11,8 @@ import {
   DependencyBindingsTestCase,
   testBindings,
 } from "@itwin/object-storage-tests-backend-unit/lib/shared/test-templates/BindingsTests";
+
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 
 import {
   AzureFrontendStorage,
@@ -28,14 +27,13 @@ describe(`${AzureFrontendStorageBindings.name}`, () => {
     const bindingsTestCases: DependencyBindingsTestCase[] = [
       {
         testedClassIdentifier: FrontendStorage.name,
-        testedFunction: (container: Container) =>
-          container.get(FrontendStorage),
+        testedFunction: (c: DIContainer) => c.resolve(FrontendStorage),
         expectedCtor: AzureFrontendStorage,
       },
       {
         testedClassIdentifier: Types.Frontend.clientWrapperFactory.toString(),
-        testedFunction: (container: Container) =>
-          container.get<FrontendBlockBlobClientWrapperFactory>(
+        testedFunction: (c: DIContainer) =>
+          c.resolve<FrontendBlockBlobClientWrapperFactory>(
             Types.Frontend.clientWrapperFactory
           ),
         expectedCtor: FrontendBlockBlobClientWrapperFactory,

--- a/storage/core/src/client/ClientStorage.ts
+++ b/storage/core/src/client/ClientStorage.ts
@@ -4,8 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 import { Readable } from "stream";
 
-import { injectable } from "inversify";
-
 import {
   ConfigDownloadInput,
   ConfigUploadInput,
@@ -14,7 +12,6 @@ import {
   UrlUploadInput,
 } from "../server";
 
-@injectable()
 export abstract class ClientStorage {
   public abstract download(
     input: (UrlDownloadInput | ConfigDownloadInput) & { transferType: "buffer" }

--- a/storage/core/src/client/ClientStorageDependency.ts
+++ b/storage/core/src/client/ClientStorageDependency.ts
@@ -2,11 +2,14 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Container } from "inversify";
 
 import { ConfigError } from "@itwin/cloud-agnostic-core/lib/internal";
 
-import { DependencyConfig, NamedDependency } from "@itwin/cloud-agnostic-core";
+import {
+  DependencyConfig,
+  DIContainer,
+  NamedDependency,
+} from "@itwin/cloud-agnostic-core";
 
 import { ClientStorage } from "./ClientStorage";
 
@@ -15,8 +18,8 @@ export abstract class ClientStorageDependency extends NamedDependency {
   public readonly dependencyType = ClientStorageDependency.dependencyType;
 
   protected override _registerInstance(
-    container: Container,
-    childContainer: Container,
+    container: DIContainer,
+    childContainer: DIContainer,
     config: DependencyConfig
   ): void {
     if (!config.instanceName)

--- a/storage/core/src/frontend/FrontendStorage.ts
+++ b/storage/core/src/frontend/FrontendStorage.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { injectable } from "inversify";
 
 import {
   FrontendConfigDownloadInput,
@@ -12,7 +11,6 @@ import {
   FrontendUrlUploadInput,
 } from "./FrontendInterfaces";
 
-@injectable()
 export abstract class FrontendStorage {
   public abstract download(
     input: (FrontendUrlDownloadInput | FrontendConfigDownloadInput) & {

--- a/storage/core/src/server/ServerStorage.ts
+++ b/storage/core/src/server/ServerStorage.ts
@@ -4,8 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 import { Readable } from "stream";
 
-import { injectable } from "inversify";
-
 import {
   BaseDirectory,
   ContentHeaders,
@@ -25,7 +23,6 @@ import {
   CopyOptions,
 } from "./Interfaces";
 
-@injectable()
 export abstract class ServerStorage
   implements PresignedUrlProvider, TransferConfigProvider
 {

--- a/storage/core/src/server/ServerStorageDependency.ts
+++ b/storage/core/src/server/ServerStorageDependency.ts
@@ -2,11 +2,14 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Container } from "inversify";
 
 import { ConfigError } from "@itwin/cloud-agnostic-core/lib/internal";
 
-import { DependencyConfig, NamedDependency } from "@itwin/cloud-agnostic-core";
+import {
+  DependencyConfig,
+  DIContainer,
+  NamedDependency,
+} from "@itwin/cloud-agnostic-core";
 
 import { ServerStorage } from "./ServerStorage";
 
@@ -15,8 +18,8 @@ export abstract class ServerStorageDependency extends NamedDependency {
   public readonly dependencyType = ServerStorageDependency.dependencyType;
 
   protected override _registerInstance(
-    container: Container,
-    childContainer: Container,
+    container: DIContainer,
+    childContainer: DIContainer,
     config: DependencyConfig
   ): void {
     if (!config.instanceName)

--- a/storage/google/src/client/GoogleClientStorage.ts
+++ b/storage/google/src/client/GoogleClientStorage.ts
@@ -5,8 +5,6 @@
 
 import { Readable } from "stream";
 
-import { injectable } from "inversify";
-
 import {
   assertRelativeDirectory,
   instanceOfUrlTransferInput,
@@ -34,7 +32,6 @@ import {
 
 import { ClientStorageWrapperFactory } from "./wrappers";
 
-@injectable()
 export class GoogleClientStorage extends ClientStorage {
   public constructor(private _storageFactory: ClientStorageWrapperFactory) {
     super();

--- a/storage/google/src/client/GoogleClientStorageBindings.ts
+++ b/storage/google/src/client/GoogleClientStorageBindings.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Container } from "inversify";
 
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 import {
   ClientStorage,
   ClientStorageDependency,
@@ -15,8 +15,15 @@ import { ClientStorageWrapperFactory } from "./wrappers";
 export class GoogleClientStorageBindings extends ClientStorageDependency {
   public readonly dependencyName: string = "google";
 
-  public override register(container: Container): void {
-    container.bind(ClientStorageWrapperFactory).toSelf().inSingletonScope();
-    container.bind(ClientStorage).to(GoogleClientStorage).inSingletonScope();
+  public override register(container: DIContainer): void {
+    container.registerFactory(
+      ClientStorageWrapperFactory,
+      () => new ClientStorageWrapperFactory()
+    );
+    container.registerFactory(
+      ClientStorage,
+      (c: DIContainer) =>
+        new GoogleClientStorage(c.resolve(ClientStorageWrapperFactory))
+    );
   }
 }

--- a/storage/google/src/frontend/GoogleFrontendStorage.ts
+++ b/storage/google/src/frontend/GoogleFrontendStorage.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { injectable } from "inversify";
 
 import {
   assertRelativeDirectory,
@@ -28,7 +27,6 @@ import {
   FrontendGoogleUploadInMultiplePartsInput,
 } from "./FrontendInterfaces";
 
-@injectable()
 export class GoogleFrontendStorage extends FrontendStorage {
   public constructor() {
     super();

--- a/storage/google/src/frontend/GoogleFrontendStorageBindings.ts
+++ b/storage/google/src/frontend/GoogleFrontendStorageBindings.ts
@@ -2,22 +2,23 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Container } from "inversify";
 
 import {
   FrontendStorage,
   FrontendStorageDependency,
 } from "@itwin/object-storage-core/lib/frontend";
 
+import { DIContainer } from "@itwin/cloud-agnostic-core";
+
 import { GoogleFrontendStorage } from "./GoogleFrontendStorage";
 
 export class GoogleFrontendStorageBindings extends FrontendStorageDependency {
   public readonly dependencyName: string = "google";
 
-  public override register(container: Container): void {
-    container
-      .bind(FrontendStorage)
-      .to(GoogleFrontendStorage)
-      .inSingletonScope();
+  public override register(container: DIContainer): void {
+    container.registerFactory(
+      FrontendStorage,
+      () => new GoogleFrontendStorage()
+    );
   }
 }

--- a/storage/google/src/server/GoogleServerStorage.ts
+++ b/storage/google/src/server/GoogleServerStorage.ts
@@ -5,8 +5,6 @@
 
 import { Readable } from "stream";
 
-import { inject, injectable } from "inversify";
-
 import {
   assertRelativeDirectory,
   buildObjectDirectoryString,
@@ -35,20 +33,18 @@ import {
   TransferType,
 } from "@itwin/object-storage-core";
 
-import { GoogleTransferConfig, Types } from "../common";
+import { GoogleTransferConfig } from "../common";
 
 import { StorageWrapper } from "./wrappers";
 import { GoogleStorageConfig } from "./wrappers/GoogleStorageConfig";
 import { StorageControlClientWrapper } from "./wrappers/StorageControlClientWrapper";
 
-@injectable()
 export class GoogleServerStorage extends ServerStorage {
   private readonly _bucketName: string;
 
   constructor(
     private readonly _storage: StorageWrapper,
     private readonly _storageControl: StorageControlClientWrapper,
-    @inject(Types.GoogleServer.config)
     config: GoogleStorageConfig
   ) {
     super();

--- a/storage/google/src/server/wrappers/StorageControlClientWrapper.ts
+++ b/storage/google/src/server/wrappers/StorageControlClientWrapper.ts
@@ -5,14 +5,13 @@
 
 import { StorageControlClient } from "@google-cloud/storage-control";
 import { DownscopedClient, GoogleAuth } from "google-auth-library";
-import { inject, injectable } from "inversify";
 
 import {
   BaseDirectory,
   EntityCollectionPage,
 } from "@itwin/object-storage-core";
 
-import { GoogleTransferConfig, Types } from "../../common";
+import { GoogleTransferConfig } from "../../common";
 
 import { GoogleStorageConfig } from "./GoogleStorageConfig";
 import { GoogleStorageConfigType, roleFromConfigType } from "./Helpers";
@@ -25,13 +24,9 @@ export function isGoogleError(error: unknown): error is GoogleError {
   return error instanceof Error && (error as GoogleError).code !== undefined;
 }
 
-@injectable()
 export class StorageControlClientWrapper {
   private readonly _client: StorageControlClient;
-  constructor(
-    @inject(Types.GoogleServer.config)
-    private readonly _config: GoogleStorageConfig
-  ) {
+  constructor(private readonly _config: GoogleStorageConfig) {
     this._client = new StorageControlClient({
       projectId: this._config.projectId,
     });

--- a/storage/google/src/server/wrappers/StorageWrapperFactory.ts
+++ b/storage/google/src/server/wrappers/StorageWrapperFactory.ts
@@ -4,14 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Storage } from "@google-cloud/storage";
-import { injectable } from "inversify";
 
 import { GoogleTransferConfig } from "../../common/Interfaces";
 
 import { GoogleStorageConfig } from "./GoogleStorageConfig";
 import { StorageWrapper } from "./StorageWrapper";
 
-@injectable()
 export class StorageWrapperFactory {
   public createDefaultApplication(config: GoogleStorageConfig): StorageWrapper {
     return new StorageWrapper(

--- a/storage/google/src/test/integration/backend/GoogleServerStorage.test.ts
+++ b/storage/google/src/test/integration/backend/GoogleServerStorage.test.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import { Storage } from "@google-cloud/storage";
 
 import {

--- a/storage/google/src/test/integration/backend/RunIntegrationTests.ts
+++ b/storage/google/src/test/integration/backend/RunIntegrationTests.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import { StorageIntegrationTests } from "@itwin/object-storage-tests-backend";
 
 import { GoogleClientStorageBindings } from "../../../client/GoogleClientStorageBindings";

--- a/storage/google/src/test/integration/frontend/GoogleFrontendTestSetup.ts
+++ b/storage/google/src/test/integration/frontend/GoogleFrontendTestSetup.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import { FrontendStorageTestSetup } from "@itwin/object-storage-tests-frontend/lib/FrontendStorageTestSetup";
 
 import { GoogleFrontendStorageBindings } from "../../../frontend";

--- a/storage/google/src/test/integration/frontend/RunIntegrationTests.ts
+++ b/storage/google/src/test/integration/frontend/RunIntegrationTests.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import * as path from "path";
 
 import { FrontendStorageIntegrationTests } from "@itwin/object-storage-tests-frontend";

--- a/storage/google/src/test/integration/frontend/StartServer.ts
+++ b/storage/google/src/test/integration/frontend/StartServer.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import {
   DependenciesConfig,
   Types as DependencyTypes,

--- a/storage/google/src/test/integration/frontend/StartServer.ts
+++ b/storage/google/src/test/integration/frontend/StartServer.ts
@@ -16,15 +16,16 @@ import { ServerStorageConfigProvider } from "../ServerStorageConfigProvider";
 function run(): void {
   const backendServer = new ServerStorageProxy();
 
-  backendServer.container
-    .bind<DependenciesConfig>(DependencyTypes.dependenciesConfig)
-    .toConstantValue({
+  backendServer.container.registerInstance<DependenciesConfig>(
+    DependencyTypes.dependenciesConfig,
+    {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       ServerStorage: {
         dependencyName: "google",
         ...new ServerStorageConfigProvider().get(),
       },
-    });
+    }
+  );
   backendServer.useBindings(GoogleServerStorageBindings);
   backendServer.start({ port: 1224 });
 }

--- a/storage/google/src/test/unit/backend/GoogleClientStorageBindings.test.ts
+++ b/storage/google/src/test/unit/backend/GoogleClientStorageBindings.test.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import { DIContainer } from "@itwin/cloud-agnostic-core";
 import { ClientStorage } from "@itwin/object-storage-core";
 import {

--- a/storage/google/src/test/unit/backend/GoogleClientStorageBindings.test.ts
+++ b/storage/google/src/test/unit/backend/GoogleClientStorageBindings.test.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import "reflect-metadata";
 
-import { Container } from "inversify";
-
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 import { ClientStorage } from "@itwin/object-storage-core";
 import {
   DependencyBindingsTestCase,
@@ -25,13 +24,13 @@ describe(`${GoogleClientStorageBindings.name}`, () => {
     const bindingsTestCases: DependencyBindingsTestCase[] = [
       {
         testedClassIdentifier: ClientStorage.name,
-        testedFunction: (container: Container) => container.get(ClientStorage),
+        testedFunction: (c: DIContainer) => c.resolve(ClientStorage),
         expectedCtor: GoogleClientStorage,
       },
       {
         testedClassIdentifier: ClientStorageWrapperFactory.name,
-        testedFunction: (container: Container) =>
-          container.get(ClientStorageWrapperFactory),
+        testedFunction: (c: DIContainer) =>
+          c.resolve(ClientStorageWrapperFactory),
         expectedCtor: ClientStorageWrapperFactory,
       },
     ];

--- a/storage/google/src/test/unit/backend/GoogleServerStorageBindings.test.ts
+++ b/storage/google/src/test/unit/backend/GoogleServerStorageBindings.test.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Container } from "inversify";
 
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 import { ServerStorage } from "@itwin/object-storage-core";
 import {
   DependencyBindingsTestCase,
@@ -52,32 +52,31 @@ describe(`${GoogleServerStorageBindings.name}`, () => {
     [
       {
         testedClassIdentifier: ServerStorage.name,
-        testedFunction: (container: Container) => container.get(ServerStorage),
+        testedFunction: (c: DIContainer) => c.resolve(ServerStorage),
         expectedCtor: GoogleServerStorage,
       },
       {
         testedClassIdentifier: Types.GoogleServer.config.toString(),
-        testedFunction: (container: Container) =>
-          container.get<GoogleServerStorageBindingsConfig>(
+        testedFunction: (c: DIContainer) =>
+          c.resolve<GoogleServerStorageBindingsConfig>(
             Types.GoogleServer.config
           ),
         expectedCtor: Object,
       },
       {
         testedClassIdentifier: StorageControlClientWrapper.name,
-        testedFunction: (container: Container) =>
-          container.get(StorageControlClientWrapper),
+        testedFunction: (c: DIContainer) =>
+          c.resolve(StorageControlClientWrapper),
         expectedCtor: StorageControlClientWrapper,
       },
       {
         testedClassIdentifier: StorageWrapperFactory.name,
-        testedFunction: (container: Container) =>
-          container.get(StorageWrapperFactory),
+        testedFunction: (c: DIContainer) => c.resolve(StorageWrapperFactory),
         expectedCtor: StorageWrapperFactory,
       },
       {
         testedClassIdentifier: StorageWrapper.name,
-        testedFunction: (container: Container) => container.get(StorageWrapper),
+        testedFunction: (c: DIContainer) => c.resolve(StorageWrapper),
         expectedCtor: StorageWrapper,
       },
     ];

--- a/storage/google/src/test/unit/backend/RunCommonUnitTests.ts
+++ b/storage/google/src/test/unit/backend/RunCommonUnitTests.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import { createStubInstance } from "sinon";
 
 import { DIContainer } from "@itwin/cloud-agnostic-core";

--- a/storage/google/src/test/unit/backend/RunCommonUnitTests.ts
+++ b/storage/google/src/test/unit/backend/RunCommonUnitTests.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 import "reflect-metadata";
 
-import { Container } from "inversify";
 import { createStubInstance } from "sinon";
 
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 import { StorageUnitTests } from "@itwin/object-storage-tests-backend-unit";
 
 import { GoogleClientStorageBindings } from "../../../client";
@@ -37,7 +37,7 @@ const googleTestConfig = {
 
 class TestGoogleServerStorageBindings extends GoogleServerStorageBindings {
   public override register(
-    container: Container,
+    container: DIContainer,
     config: GoogleServerStorageBindingsConfig
   ): void {
     super.register(container, config);
@@ -47,20 +47,24 @@ class TestGoogleServerStorageBindings extends GoogleServerStorageBindings {
     );
     const mockStorageWrapper = createStubInstance(StorageWrapper);
 
-    container
-      .rebind(StorageControlClientWrapper)
-      .toConstantValue(mockStorageControlClient);
-    container.rebind(StorageWrapper).toConstantValue(mockStorageWrapper);
+    container.unregister(StorageControlClientWrapper);
+    container.registerInstance(
+      StorageControlClientWrapper,
+      mockStorageControlClient
+    );
+    container.unregister(StorageWrapper);
+    container.registerInstance(StorageWrapper, mockStorageWrapper);
   }
 }
 
 class TestGoogleClientStorageBindings extends GoogleClientStorageBindings {
-  public override register(container: Container): void {
+  public override register(container: DIContainer): void {
     super.register(container);
 
     const mockStorageWrapper = createStubInstance(StorageWrapper);
 
-    container.rebind(StorageWrapper).toConstantValue(mockStorageWrapper);
+    container.unregister(StorageWrapper);
+    container.registerInstance(StorageWrapper, mockStorageWrapper);
   }
 }
 

--- a/storage/google/src/test/unit/frontend/GoogleFrontendStorageBindings.test.ts
+++ b/storage/google/src/test/unit/frontend/GoogleFrontendStorageBindings.test.ts
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 import "reflect-metadata";
 
-import { Container } from "inversify";
-
 import { FrontendStorage } from "@itwin/object-storage-core/lib/frontend";
 import {
   DependencyBindingsTestCase,
   testBindings,
 } from "@itwin/object-storage-tests-backend-unit/lib/shared/test-templates/BindingsTests";
+
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 
 import {
   GoogleFrontendStorage,
@@ -24,8 +24,7 @@ describe(`${GoogleFrontendStorageBindings.name}`, () => {
     const bindingsTestCases: DependencyBindingsTestCase[] = [
       {
         testedClassIdentifier: FrontendStorage.name,
-        testedFunction: (container: Container) =>
-          container.get(FrontendStorage),
+        testedFunction: (c: DIContainer) => c.resolve(FrontendStorage),
         expectedCtor: GoogleFrontendStorage,
       },
     ];

--- a/storage/google/src/test/unit/frontend/GoogleFrontendStorageBindings.test.ts
+++ b/storage/google/src/test/unit/frontend/GoogleFrontendStorageBindings.test.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import { FrontendStorage } from "@itwin/object-storage-core/lib/frontend";
 import {
   DependencyBindingsTestCase,

--- a/storage/minio/src/client/MinioClientStorageBindings.ts
+++ b/storage/minio/src/client/MinioClientStorageBindings.ts
@@ -4,19 +4,24 @@
  *--------------------------------------------------------------------------------------------*/
 import "reflect-metadata";
 
-import { Container } from "inversify";
-
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 import { ClientStorage } from "@itwin/object-storage-core";
-import { S3ClientStorageBindings } from "@itwin/object-storage-s3";
+import {
+  S3ClientStorageBindings,
+  S3ClientWrapperFactory,
+} from "@itwin/object-storage-s3";
 
 import { MinioClientStorage } from "./MinioClientStorage";
 
 export class MinioClientStorageBindings extends S3ClientStorageBindings {
   public override readonly dependencyName: string = "minio";
 
-  public override register(container: Container): void {
+  public override register(container: DIContainer): void {
     super.register(container);
 
-    container.rebind(ClientStorage).to(MinioClientStorage).inSingletonScope();
+    container.unregister(ClientStorage);
+    container.registerFactory(ClientStorage, (c: DIContainer) => {
+      return new MinioClientStorage(c.resolve(S3ClientWrapperFactory));
+    });
   }
 }

--- a/storage/minio/src/client/MinioClientStorageBindings.ts
+++ b/storage/minio/src/client/MinioClientStorageBindings.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import { DIContainer } from "@itwin/cloud-agnostic-core";
 import { ClientStorage, Types as CoreTypes } from "@itwin/object-storage-core";
 import {

--- a/storage/minio/src/client/MinioClientStorageBindings.ts
+++ b/storage/minio/src/client/MinioClientStorageBindings.ts
@@ -5,7 +5,7 @@
 import "reflect-metadata";
 
 import { DIContainer } from "@itwin/cloud-agnostic-core";
-import { ClientStorage } from "@itwin/object-storage-core";
+import { ClientStorage, Types as CoreTypes } from "@itwin/object-storage-core";
 import {
   S3ClientStorageBindings,
   S3ClientWrapperFactory,
@@ -21,7 +21,9 @@ export class MinioClientStorageBindings extends S3ClientStorageBindings {
 
     container.unregister(ClientStorage);
     container.registerFactory(ClientStorage, (c: DIContainer) => {
-      return new MinioClientStorage(c.resolve(S3ClientWrapperFactory));
+      return new MinioClientStorage(
+        c.resolve<S3ClientWrapperFactory>(CoreTypes.Client.clientWrapperFactory)
+      );
     });
   }
 }

--- a/storage/minio/src/frontend/MinioFrontendStorageBindings.ts
+++ b/storage/minio/src/frontend/MinioFrontendStorageBindings.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import {
   Types as CoreTypes,
   FrontendStorage,

--- a/storage/minio/src/frontend/MinioFrontendStorageBindings.ts
+++ b/storage/minio/src/frontend/MinioFrontendStorageBindings.ts
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 import "reflect-metadata";
 
-import { Container } from "inversify";
-
 import {
   Types as CoreTypes,
   FrontendStorage,
 } from "@itwin/object-storage-core/lib/frontend";
 import { S3FrontendStorageBindings } from "@itwin/object-storage-s3/lib/frontend";
+
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 
 import { MinioFrontendStorage } from "./MinioFrontendStorage";
 import { FrontendMinioS3ClientWrapperFactory } from "./wrappers/FrontendMinioS3ClientFactory";
@@ -18,17 +18,24 @@ import { FrontendMinioS3ClientWrapperFactory } from "./wrappers/FrontendMinioS3C
 export class MinioFrontendStorageBindings extends S3FrontendStorageBindings {
   public override readonly dependencyName: string = "minio";
 
-  public override register(container: Container): void {
+  public override register(container: DIContainer): void {
     super.register(container);
 
-    container
-      .rebind(FrontendStorage)
-      .to(MinioFrontendStorage)
-      .inSingletonScope();
+    container.unregister(FrontendStorage);
+    container.registerFactory(
+      FrontendStorage,
+      (c: DIContainer) =>
+        new MinioFrontendStorage(
+          c.resolve<FrontendMinioS3ClientWrapperFactory>(
+            CoreTypes.Frontend.clientWrapperFactory
+          )
+        )
+    );
 
-    container
-      .rebind(CoreTypes.Frontend.clientWrapperFactory)
-      .to(FrontendMinioS3ClientWrapperFactory)
-      .inSingletonScope();
+    container.unregister(CoreTypes.Frontend.clientWrapperFactory);
+    container.registerFactory(
+      CoreTypes.Frontend.clientWrapperFactory,
+      () => new FrontendMinioS3ClientWrapperFactory()
+    );
   }
 }

--- a/storage/minio/src/frontend/wrappers/FrontendMinioS3ClientFactory.ts
+++ b/storage/minio/src/frontend/wrappers/FrontendMinioS3ClientFactory.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { injectable } from "inversify";
 
 import { TransferConfig } from "@itwin/object-storage-core/lib/frontend";
 import { assertS3TransferConfig } from "@itwin/object-storage-s3/lib/common/internal";
@@ -10,7 +9,6 @@ import { FrontendS3ClientWrapper } from "@itwin/object-storage-s3/lib/frontend";
 
 import { createMinioS3ClientFrontend } from "../internal";
 
-@injectable()
 export class FrontendMinioS3ClientWrapperFactory {
   public create(transferConfig: TransferConfig): FrontendS3ClientWrapper {
     assertS3TransferConfig(transferConfig);

--- a/storage/minio/src/server/MinioPresignedUrlProvider.ts
+++ b/storage/minio/src/server/MinioPresignedUrlProvider.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { inject, injectable } from "inversify";
 import { Client } from "minio";
 
 import { buildObjectKey } from "@itwin/object-storage-core/lib/common/internal";
@@ -13,15 +12,12 @@ import {
   ObjectReference,
   PresignedUrlProvider,
 } from "@itwin/object-storage-core";
-import { Types } from "@itwin/object-storage-s3";
 
-@injectable()
 export class MinioPresignedUrlProvider implements PresignedUrlProvider {
   private readonly _client: Client;
   private readonly _bucket: string;
 
-  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
-  public constructor(client: Client, @inject(Types.bucket) bucket: string) {
+  public constructor(client: Client, bucket: string) {
     this._client = client;
     this._bucket = bucket;
   }

--- a/storage/minio/src/server/MinioServerStorageBindings.ts
+++ b/storage/minio/src/server/MinioServerStorageBindings.ts
@@ -2,17 +2,22 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Container } from "inversify";
+
 import { Client } from "minio";
 
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 import {
   PresignedUrlProvider,
   ServerStorage,
+  TransferConfigProvider,
   Types,
 } from "@itwin/object-storage-core";
 import {
+  S3ClientWrapper,
   S3ServerStorageBindings,
   S3ServerStorageBindingsConfig,
+  S3ServerStorageConfig,
+  Types as S3Types,
 } from "@itwin/object-storage-s3";
 
 import { createClient } from "./internal";
@@ -23,17 +28,36 @@ export class MinioServerStorageBindings extends S3ServerStorageBindings {
   public override readonly dependencyName: string = "minio";
 
   public override register(
-    container: Container,
+    container: DIContainer,
     config: S3ServerStorageBindingsConfig
   ): void {
     super.register(container, config);
 
-    container
-      .rebind<PresignedUrlProvider>(Types.Server.presignedUrlProvider)
-      .to(MinioPresignedUrlProvider)
-      .inSingletonScope();
+    container.unregister(Types.Server.presignedUrlProvider);
+    container.registerFactory<PresignedUrlProvider>(
+      Types.Server.presignedUrlProvider,
+      (c: DIContainer) =>
+        new MinioPresignedUrlProvider(
+          c.resolve(Client),
+          c.resolve<string>(S3Types.bucket)
+        )
+    );
 
-    container.bind(Client).toConstantValue(createClient(config));
-    container.rebind(ServerStorage).to(MinioServerStorage).inSingletonScope();
+    container.registerFactory<Client>(Client, (c: DIContainer) => {
+      const resolvedConfig = c.resolve<S3ServerStorageConfig>(
+        S3Types.S3Server.config
+      );
+      return createClient(resolvedConfig);
+    });
+    container.unregister(ServerStorage);
+    container.registerFactory<ServerStorage>(
+      ServerStorage,
+      (c: DIContainer) =>
+        new MinioServerStorage(
+          c.resolve(S3ClientWrapper),
+          c.resolve<PresignedUrlProvider>(Types.Server.presignedUrlProvider),
+          c.resolve<TransferConfigProvider>(Types.Server.transferConfigProvider)
+        )
+    );
   }
 }

--- a/storage/minio/src/test/integration/backend/MinioServerStorage.test.ts
+++ b/storage/minio/src/test/integration/backend/MinioServerStorage.test.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import {
   DeleteObjectCommand,
   ListObjectsV2Command,

--- a/storage/minio/src/test/integration/backend/RunIntegrationTests.ts
+++ b/storage/minio/src/test/integration/backend/RunIntegrationTests.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import { StorageIntegrationTests } from "@itwin/object-storage-tests-backend";
 
 import { MinioClientStorageBindings } from "../../../client";

--- a/storage/minio/src/test/integration/frontend/MinioFrontendTestSetup.ts
+++ b/storage/minio/src/test/integration/frontend/MinioFrontendTestSetup.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import { FrontendStorageTestSetup } from "@itwin/object-storage-tests-frontend/lib/FrontendStorageTestSetup";
 
 import { MinioFrontendStorageBindings } from "../../../frontend";

--- a/storage/minio/src/test/integration/frontend/RunIntegrationTests.ts
+++ b/storage/minio/src/test/integration/frontend/RunIntegrationTests.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import * as path from "path";
 
 import { FrontendStorageIntegrationTests } from "@itwin/object-storage-tests-frontend";

--- a/storage/minio/src/test/integration/frontend/StartServer.ts
+++ b/storage/minio/src/test/integration/frontend/StartServer.ts
@@ -16,15 +16,16 @@ import { ServerStorageConfigProvider } from "../ServerStorageConfigProvider";
 function run(): void {
   const backendServer = new ServerStorageProxy();
 
-  backendServer.container
-    .bind<DependenciesConfig>(DependencyTypes.dependenciesConfig)
-    .toConstantValue({
+  backendServer.container.registerInstance<DependenciesConfig>(
+    DependencyTypes.dependenciesConfig,
+    {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       ServerStorage: {
         dependencyName: "minio",
         ...new ServerStorageConfigProvider().get(),
       },
-    });
+    }
+  );
   backendServer.useBindings(MinioServerStorageBindings);
   backendServer.start({ port: 1222 });
 }

--- a/storage/minio/src/test/integration/frontend/StartServer.ts
+++ b/storage/minio/src/test/integration/frontend/StartServer.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import {
   DependenciesConfig,
   Types as DependencyTypes,

--- a/storage/minio/src/test/unit/backend/MinioClientStorageBindings.test.ts
+++ b/storage/minio/src/test/unit/backend/MinioClientStorageBindings.test.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import { DIContainer } from "@itwin/cloud-agnostic-core";
 import { ClientStorage } from "@itwin/object-storage-core";
 import {

--- a/storage/minio/src/test/unit/backend/MinioClientStorageBindings.test.ts
+++ b/storage/minio/src/test/unit/backend/MinioClientStorageBindings.test.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import "reflect-metadata";
 
-import { Container } from "inversify";
-
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 import { ClientStorage } from "@itwin/object-storage-core";
 import {
   DependencyBindingsTestCase,
@@ -24,7 +23,7 @@ describe(`${MinioClientStorageBindings.name}`, () => {
     const bindingsTestCases: DependencyBindingsTestCase[] = [
       {
         testedClassIdentifier: ClientStorage.name,
-        testedFunction: (container: Container) => container.get(ClientStorage),
+        testedFunction: (c: DIContainer) => c.resolve(ClientStorage),
         expectedCtor: MinioClientStorage,
       },
     ];

--- a/storage/minio/src/test/unit/backend/MinioServerStorageBindings.test.ts
+++ b/storage/minio/src/test/unit/backend/MinioServerStorageBindings.test.ts
@@ -2,9 +2,10 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Container } from "inversify";
+
 import { Client } from "minio";
 
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 import {
   PresignedUrlProvider,
   ServerStorage,
@@ -29,20 +30,18 @@ describe(`${MinioServerStorageBindings.name}`, () => {
     const bindingsTestCases: DependencyBindingsTestCase[] = [
       {
         testedClassIdentifier: ServerStorage.name,
-        testedFunction: (container: Container) => container.get(ServerStorage),
+        testedFunction: (c: DIContainer) => c.resolve(ServerStorage),
         expectedCtor: MinioServerStorage,
       },
       {
         testedClassIdentifier: Types.Server.presignedUrlProvider.toString(),
-        testedFunction: (container: Container) =>
-          container.get<PresignedUrlProvider>(
-            Types.Server.presignedUrlProvider
-          ),
+        testedFunction: (c: DIContainer) =>
+          c.resolve<PresignedUrlProvider>(Types.Server.presignedUrlProvider),
         expectedCtor: MinioPresignedUrlProvider,
       },
       {
         testedClassIdentifier: Client.name,
-        testedFunction: (container: Container) => container.get(Client),
+        testedFunction: (c: DIContainer) => c.resolve(Client),
         expectedCtor: Client,
       },
     ];

--- a/storage/minio/src/test/unit/backend/RunCommonUnitTests.ts
+++ b/storage/minio/src/test/unit/backend/RunCommonUnitTests.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 import "reflect-metadata";
 
-import { Container } from "inversify";
 import { Client } from "minio";
 import { createStubInstance } from "sinon";
 
@@ -14,6 +13,7 @@ import {
   s3TestConfig,
 } from "@itwin/object-storage-s3/lib/test/unit/backend/CommonUnitTestUtils";
 
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 import { S3ServerStorageBindingsConfig } from "@itwin/object-storage-s3";
 import { StorageUnitTests } from "@itwin/object-storage-tests-backend-unit";
 
@@ -39,7 +39,7 @@ const minioTestConfig = {
 
 class TestMinioServerStorageBindings extends MinioServerStorageBindings {
   public override register(
-    container: Container,
+    container: DIContainer,
     config: S3ServerStorageBindingsConfig
   ): void {
     super.register(container, config);
@@ -47,12 +47,13 @@ class TestMinioServerStorageBindings extends MinioServerStorageBindings {
 
     const mockClient = createStubInstance(Client);
 
-    container.rebind(Client).toConstantValue(mockClient);
+    container.unregister(Client);
+    container.registerInstance(Client, mockClient);
   }
 }
 
 class TestMinioClientStorageBindings extends MinioClientStorageBindings {
-  public override register(container: Container): void {
+  public override register(container: DIContainer): void {
     super.register(container);
     rebindS3Client(container);
   }

--- a/storage/minio/src/test/unit/backend/RunCommonUnitTests.ts
+++ b/storage/minio/src/test/unit/backend/RunCommonUnitTests.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import { Client } from "minio";
 import { createStubInstance } from "sinon";
 

--- a/storage/minio/src/test/unit/frontend/MinioFrontendStorageBindings.test.ts
+++ b/storage/minio/src/test/unit/frontend/MinioFrontendStorageBindings.test.ts
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 import "reflect-metadata";
 
-import { Container } from "inversify";
-
 import { FrontendStorage } from "@itwin/object-storage-core/lib/frontend";
 import {
   DependencyBindingsTestCase,
   testBindings,
 } from "@itwin/object-storage-tests-backend-unit/lib/shared/test-templates/BindingsTests";
+
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 
 import {
   MinioFrontendStorage,
@@ -24,8 +24,7 @@ describe(`${MinioFrontendStorageBindings.name}`, () => {
     const bindingsTestCases: DependencyBindingsTestCase[] = [
       {
         testedClassIdentifier: FrontendStorage.name,
-        testedFunction: (container: Container) =>
-          container.get(FrontendStorage),
+        testedFunction: (c: DIContainer) => c.resolve(FrontendStorage),
         expectedCtor: MinioFrontendStorage,
       },
     ];

--- a/storage/minio/src/test/unit/frontend/MinioFrontendStorageBindings.test.ts
+++ b/storage/minio/src/test/unit/frontend/MinioFrontendStorageBindings.test.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import { FrontendStorage } from "@itwin/object-storage-core/lib/frontend";
 import {
   DependencyBindingsTestCase,

--- a/storage/oss/src/frontend/OssFrontendStorageBindings.ts
+++ b/storage/oss/src/frontend/OssFrontendStorageBindings.ts
@@ -2,20 +2,22 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Container } from "inversify";
 
 import { Types as CoreTypes } from "@itwin/object-storage-core/lib/frontend";
 import { S3FrontendStorageBindings } from "@itwin/object-storage-s3/lib/frontend";
 
+import { DIContainer } from "@itwin/cloud-agnostic-core";
+
 import { FrontendOssS3ClientWrapperFactory } from "./wrappers";
 
 export class OssFrontendStorageBindings extends S3FrontendStorageBindings {
-  public override register(container: Container): void {
+  public override register(container: DIContainer): void {
     super.register(container);
 
-    container
-      .rebind(CoreTypes.Frontend.clientWrapperFactory)
-      .to(FrontendOssS3ClientWrapperFactory)
-      .inSingletonScope();
+    container.unregister(CoreTypes.Frontend.clientWrapperFactory);
+    container.registerFactory(
+      CoreTypes.Frontend.clientWrapperFactory,
+      () => new FrontendOssS3ClientWrapperFactory()
+    );
   }
 }

--- a/storage/oss/src/frontend/wrappers/FrontendOssS3ClientFactory.ts
+++ b/storage/oss/src/frontend/wrappers/FrontendOssS3ClientFactory.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { injectable } from "inversify";
 
 import { TransferConfig } from "@itwin/object-storage-core/lib/frontend";
 import { assertS3TransferConfig } from "@itwin/object-storage-s3/lib/common/internal";
@@ -10,7 +9,6 @@ import { FrontendS3ClientWrapper } from "@itwin/object-storage-s3/lib/frontend";
 
 import { createOssS3ClientFrontend } from "../internal";
 
-@injectable()
 export class FrontendOssS3ClientWrapperFactory {
   public create(transferConfig: TransferConfig): FrontendS3ClientWrapper {
     assertS3TransferConfig(transferConfig);

--- a/storage/oss/src/server/OssServerStorageBindings.ts
+++ b/storage/oss/src/server/OssServerStorageBindings.ts
@@ -35,7 +35,6 @@ export class OssServerStorageBindings extends S3ServerStorageBindings {
         );
       }
     );
-    container.unregister(Core);
     container.registerFactory(Core, (c: DIContainer) => {
       const resolvedConfig = c.resolve<S3ServerStorageConfig>(
         S3Types.S3Server.config

--- a/storage/oss/src/server/OssServerStorageBindings.ts
+++ b/storage/oss/src/server/OssServerStorageBindings.ts
@@ -3,12 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as Core from "@alicloud/pop-core";
-import { Container } from "inversify";
 
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 import { TransferConfigProvider, Types } from "@itwin/object-storage-core";
 import {
   S3ServerStorageBindings,
   S3ServerStorageBindingsConfig,
+  S3ServerStorageConfig,
+  Types as S3Types,
 } from "@itwin/object-storage-s3";
 
 import { createCore } from "./internal";
@@ -18,15 +20,27 @@ export class OssServerStorageBindings extends S3ServerStorageBindings {
   public override readonly dependencyName: string = "oss";
 
   public override register(
-    container: Container,
+    container: DIContainer,
     config: S3ServerStorageBindingsConfig
   ): void {
     super.register(container, config);
 
-    container
-      .rebind<TransferConfigProvider>(Types.Server.transferConfigProvider)
-      .to(OssTransferConfigProvider)
-      .inSingletonScope();
-    container.bind(Core).toConstantValue(createCore(config));
+    container.unregister(Types.Server.transferConfigProvider);
+    container.registerFactory<TransferConfigProvider>(
+      Types.Server.transferConfigProvider,
+      (c: DIContainer) => {
+        return new OssTransferConfigProvider(
+          c.resolve<Core>(Core),
+          c.resolve<S3ServerStorageConfig>(S3Types.S3Server.config)
+        );
+      }
+    );
+    container.unregister(Core);
+    container.registerFactory(Core, (c: DIContainer) => {
+      const resolvedConfig = c.resolve<S3ServerStorageConfig>(
+        S3Types.S3Server.config
+      );
+      return createCore(resolvedConfig);
+    });
   }
 }

--- a/storage/oss/src/server/OssTransferConfigProvider.ts
+++ b/storage/oss/src/server/OssTransferConfigProvider.ts
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as Core from "@alicloud/pop-core";
-import { inject, injectable } from "inversify";
 
 import { buildObjectDirectoryString } from "@itwin/object-storage-core/lib/common/internal";
 import { getRandomString } from "@itwin/object-storage-core/lib/server/internal";
@@ -17,20 +16,15 @@ import {
 import {
   S3ServerStorageConfig,
   S3TransferConfig,
-  Types,
 } from "@itwin/object-storage-s3";
 
 import { getActions } from "./internal";
 
-@injectable()
 export class OssTransferConfigProvider implements TransferConfigProvider {
   private readonly _config: S3ServerStorageConfig;
   private readonly _client: Core;
 
-  public constructor(
-    client: Core,
-    @inject(Types.S3Server.config) config: S3ServerStorageConfig
-  ) {
+  public constructor(client: Core, config: S3ServerStorageConfig) {
     this._config = config;
     this._client = client;
   }

--- a/storage/oss/src/test/integration/backend/OssServerStorage.test.ts
+++ b/storage/oss/src/test/integration/backend/OssServerStorage.test.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import {
   DeleteObjectCommand,
   ListObjectsV2Command,

--- a/storage/oss/src/test/integration/backend/RunIntegrationTests.ts
+++ b/storage/oss/src/test/integration/backend/RunIntegrationTests.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import { S3ClientStorageBindings } from "@itwin/object-storage-s3";
 import { StorageIntegrationTests } from "@itwin/object-storage-tests-backend";
 

--- a/storage/oss/src/test/integration/frontend/StartServer.ts
+++ b/storage/oss/src/test/integration/frontend/StartServer.ts
@@ -14,15 +14,16 @@ import { ServerStorageConfigProvider } from "../ServerStorageConfigProvider";
 function run(): void {
   const backendServer = new ServerStorageProxy();
 
-  backendServer.container
-    .bind<DependenciesConfig>(DependencyTypes.dependenciesConfig)
-    .toConstantValue({
+  backendServer.container.registerInstance<DependenciesConfig>(
+    DependencyTypes.dependenciesConfig,
+    {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       ServerStorage: {
         dependencyName: "oss",
         ...new ServerStorageConfigProvider().get(),
       },
-    });
+    }
+  );
   backendServer.useBindings(OssServerStorageBindings);
   backendServer.start({ port: 1223 });
 }

--- a/storage/oss/src/test/unit/backend/OssServerStorageBindings.test.ts
+++ b/storage/oss/src/test/unit/backend/OssServerStorageBindings.test.ts
@@ -5,8 +5,8 @@
 import "reflect-metadata";
 
 import * as Core from "@alicloud/pop-core";
-import { Container } from "inversify";
 
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 import { TransferConfigProvider, Types } from "@itwin/object-storage-core";
 import {
   Constants,
@@ -26,15 +26,15 @@ describe(`${OssServerStorageBindings.name}`, () => {
     const bindingsTestCases: DependencyBindingsTestCase[] = [
       {
         testedClassIdentifier: Types.Server.transferConfigProvider.toString(),
-        testedFunction: (container: Container) =>
-          container.get<TransferConfigProvider>(
+        testedFunction: (c: DIContainer) =>
+          c.resolve<TransferConfigProvider>(
             Types.Server.transferConfigProvider
           ),
         expectedCtor: OssTransferConfigProvider,
       },
       {
         testedClassIdentifier: Core.name,
-        testedFunction: (container: Container) => container.get(Core),
+        testedFunction: (c: DIContainer) => c.resolve(Core),
         expectedCtor: Core,
       },
     ];

--- a/storage/oss/src/test/unit/backend/OssServerStorageBindings.test.ts
+++ b/storage/oss/src/test/unit/backend/OssServerStorageBindings.test.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import * as Core from "@alicloud/pop-core";
 
 import { DIContainer } from "@itwin/cloud-agnostic-core";

--- a/storage/s3/src/client/S3ClientStorage.ts
+++ b/storage/s3/src/client/S3ClientStorage.ts
@@ -6,7 +6,6 @@ import { createReadStream } from "fs";
 import { Readable } from "stream";
 
 import type { HttpHandlerOptions } from "@aws-sdk/types";
-import { inject, injectable } from "inversify";
 
 import {
   assertRelativeDirectory,
@@ -21,7 +20,6 @@ import {
 import {
   ClientStorage,
   TransferData,
-  Types,
   UrlDownloadInput,
   UrlUploadInput,
 } from "@itwin/object-storage-core";
@@ -37,12 +35,8 @@ import { createAndUseClient } from "../server/internal";
 
 import { handleS3UrlUpload } from "./internal/Helpers";
 
-@injectable()
 export class S3ClientStorage extends ClientStorage {
-  constructor(
-    @inject(Types.Client.clientWrapperFactory)
-    private _clientWrapperFactory: S3ClientWrapperFactory
-  ) {
+  constructor(private _clientWrapperFactory: S3ClientWrapperFactory) {
     super();
   }
 

--- a/storage/s3/src/client/S3ClientStorageBindings.ts
+++ b/storage/s3/src/client/S3ClientStorageBindings.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Container } from "inversify";
 
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 import {
   ClientStorage,
   ClientStorageDependency,
@@ -17,11 +17,18 @@ import { S3ClientStorage } from "./S3ClientStorage";
 export class S3ClientStorageBindings extends ClientStorageDependency {
   public readonly dependencyName: string = "s3";
 
-  public override register(container: Container): void {
-    container
-      .bind(CoreTypes.Client.clientWrapperFactory)
-      .to(S3ClientWrapperFactory)
-      .inSingletonScope();
-    container.bind(ClientStorage).to(S3ClientStorage).inSingletonScope();
+  public override register(container: DIContainer): void {
+    container.registerFactory<S3ClientWrapperFactory>(
+      CoreTypes.Client.clientWrapperFactory,
+      () => new S3ClientWrapperFactory()
+    );
+    container.registerFactory<ClientStorage>(
+      ClientStorage,
+      (c: DIContainer) => {
+        return new S3ClientStorage(
+          c.resolve(CoreTypes.Client.clientWrapperFactory)
+        );
+      }
+    );
   }
 }

--- a/storage/s3/src/frontend/S3FrontendStorage.ts
+++ b/storage/s3/src/frontend/S3FrontendStorage.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { inject, injectable } from "inversify";
-
 import {
   assertRelativeDirectory,
   instanceOfUrlTransferInput,
@@ -16,7 +14,6 @@ import {
   FrontendUploadInMultiplePartsInput,
   FrontendUrlDownloadInput,
   FrontendUrlUploadInput,
-  Types,
 } from "@itwin/object-storage-core/lib/frontend";
 import {
   downloadFromUrlFrontend,
@@ -31,10 +28,8 @@ import {
   FrontendS3ClientWrapperFactory,
 } from "./wrappers";
 
-@injectable()
 export class S3FrontendStorage extends FrontendStorage {
   public constructor(
-    @inject(Types.Frontend.clientWrapperFactory)
     private _clientWrapperFactory: FrontendS3ClientWrapperFactory
   ) {
     super();

--- a/storage/s3/src/frontend/S3FrontendStorageBindings.ts
+++ b/storage/s3/src/frontend/S3FrontendStorageBindings.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Container } from "inversify";
 
 import {
   Types as CoreTypes,
@@ -10,17 +9,25 @@ import {
   FrontendStorageDependency,
 } from "@itwin/object-storage-core/lib/frontend";
 
+import { DIContainer } from "@itwin/cloud-agnostic-core";
+
 import { S3FrontendStorage } from "./S3FrontendStorage";
 import { FrontendS3ClientWrapperFactory } from "./wrappers";
 
 export class S3FrontendStorageBindings extends FrontendStorageDependency {
   public readonly dependencyName: string = "s3";
 
-  public override register(container: Container): void {
-    container
-      .bind(CoreTypes.Frontend.clientWrapperFactory)
-      .to(FrontendS3ClientWrapperFactory)
-      .inSingletonScope();
-    container.bind(FrontendStorage).to(S3FrontendStorage).inSingletonScope();
+  public override register(container: DIContainer): void {
+    container.registerFactory(
+      CoreTypes.Frontend.clientWrapperFactory,
+      () => new FrontendS3ClientWrapperFactory()
+    );
+    container.registerFactory(
+      FrontendStorage,
+      (c: DIContainer) =>
+        new S3FrontendStorage(
+          c.resolve(CoreTypes.Frontend.clientWrapperFactory)
+        )
+    );
   }
 }

--- a/storage/s3/src/frontend/wrappers/FrontendS3ClientWrapper.ts
+++ b/storage/s3/src/frontend/wrappers/FrontendS3ClientWrapper.ts
@@ -12,7 +12,6 @@ import {
   S3Client,
 } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
-import { inject, injectable } from "inversify";
 
 import {
   buildObjectKey,
@@ -27,13 +26,10 @@ import {
   ObjectReference,
 } from "@itwin/object-storage-core/lib/frontend";
 
-import { Types } from "../../common";
-
-@injectable()
 export class FrontendS3ClientWrapper {
   public constructor(
     protected readonly _client: S3Client,
-    @inject(Types.bucket) protected readonly _bucket: string
+    protected readonly _bucket: string
   ) {}
 
   public async download(reference: ObjectReference): Promise<ReadableStream> {

--- a/storage/s3/src/frontend/wrappers/FrontendS3ClientWrapperFactory.ts
+++ b/storage/s3/src/frontend/wrappers/FrontendS3ClientWrapperFactory.ts
@@ -2,15 +2,12 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { injectable } from "inversify";
-
 import { TransferConfig } from "@itwin/object-storage-core/lib/frontend";
 
 import { assertS3TransferConfig, createS3Client } from "../../common/internal";
 
 import { FrontendS3ClientWrapper } from "./FrontendS3ClientWrapper";
 
-@injectable()
 export class FrontendS3ClientWrapperFactory {
   public create(transferConfig: TransferConfig): FrontendS3ClientWrapper {
     assertS3TransferConfig(transferConfig);

--- a/storage/s3/src/server/S3PresignedUrlProvider.ts
+++ b/storage/s3/src/server/S3PresignedUrlProvider.ts
@@ -8,7 +8,6 @@ import {
   S3Client,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { inject, injectable } from "inversify";
 
 import { buildObjectKey } from "@itwin/object-storage-core/lib/common/internal";
 
@@ -18,17 +17,13 @@ import {
   PresignedUrlProvider,
 } from "@itwin/object-storage-core";
 
-import { Types } from "../common";
-
 import { getExpiresInSeconds } from "./internal";
 
-@injectable()
 export class S3PresignedUrlProvider implements PresignedUrlProvider {
   private readonly _client: S3Client;
   private readonly _bucket: string;
 
-  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
-  public constructor(client: S3Client, @inject(Types.bucket) bucket: string) {
+  public constructor(client: S3Client, bucket: string) {
     this._client = client;
     this._bucket = bucket;
   }

--- a/storage/s3/src/server/S3ServerStorage.ts
+++ b/storage/s3/src/server/S3ServerStorage.ts
@@ -5,8 +5,6 @@
 import { createReadStream } from "fs";
 import { Readable } from "stream";
 
-import { inject, injectable } from "inversify";
-
 import { assertRelativeDirectory } from "@itwin/object-storage-core/lib/common/internal";
 import {
   assertFileNotEmpty,
@@ -30,7 +28,6 @@ import {
   TransferData,
   TransferType,
   EntityPageListIterator,
-  Types,
 } from "@itwin/object-storage-core";
 
 import { S3ClientWrapper } from "./wrappers";
@@ -45,7 +42,6 @@ export interface S3ServerStorageConfig {
   stsBaseUrl: string;
 }
 
-@injectable()
 export class S3ServerStorage extends ServerStorage {
   private readonly _presignedUrlProvider: PresignedUrlProvider;
   private readonly _transferConfigProvider: TransferConfigProvider;
@@ -53,11 +49,7 @@ export class S3ServerStorage extends ServerStorage {
 
   public constructor(
     s3Client: S3ClientWrapper,
-    // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
-    @inject(Types.Server.presignedUrlProvider)
     presignedUrlProvider: PresignedUrlProvider,
-    // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
-    @inject(Types.Server.transferConfigProvider)
     transferConfigProvider: TransferConfigProvider
   ) {
     super();

--- a/storage/s3/src/server/S3TransferConfigProvider.ts
+++ b/storage/s3/src/server/S3TransferConfigProvider.ts
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { AssumeRoleCommand, STSClient } from "@aws-sdk/client-sts";
-import { inject, injectable } from "inversify";
 
 import { buildObjectDirectoryString } from "@itwin/object-storage-core/lib/common/internal";
 import { getRandomString } from "@itwin/object-storage-core/lib/server/internal";
@@ -14,21 +13,16 @@ import {
   TransferConfigProvider,
 } from "@itwin/object-storage-core";
 
-import { S3TransferConfig, Types } from "../common";
+import { S3TransferConfig } from "../common";
 
 import { getActions, getExpiresInSeconds } from "./internal";
 import { S3ServerStorageConfig } from "./S3ServerStorage";
 
-@injectable()
 export class S3TransferConfigProvider implements TransferConfigProvider {
   private readonly _config: S3ServerStorageConfig;
   private readonly _client: STSClient;
 
-  public constructor(
-    client: STSClient,
-    // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
-    @inject(Types.S3Server.config) config: S3ServerStorageConfig
-  ) {
+  public constructor(client: STSClient, config: S3ServerStorageConfig) {
     this._config = config;
     this._client = client;
   }

--- a/storage/s3/src/server/wrappers/S3ClientWrapper.ts
+++ b/storage/s3/src/server/wrappers/S3ClientWrapper.ts
@@ -16,7 +16,6 @@ import {
 } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
 import type { HttpHandlerOptions } from "@aws-sdk/types";
-import { inject, injectable } from "inversify";
 
 import {
   buildObjectKey,
@@ -36,13 +35,10 @@ import {
   TransferData,
 } from "@itwin/object-storage-core";
 
-import { Types } from "../../common";
-
-@injectable()
 export class S3ClientWrapper {
   public constructor(
     protected readonly _client: S3Client,
-    @inject(Types.bucket) protected readonly _bucket: string
+    protected readonly _bucket: string
   ) {}
 
   public async download(

--- a/storage/s3/src/server/wrappers/S3ClientWrapperFactory.ts
+++ b/storage/s3/src/server/wrappers/S3ClientWrapperFactory.ts
@@ -2,15 +2,12 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { injectable } from "inversify";
-
 import { TransferConfig } from "@itwin/object-storage-core";
 
 import { assertS3TransferConfig, createS3Client } from "../../common/internal";
 
 import { S3ClientWrapper } from "./S3ClientWrapper";
 
-@injectable()
 export class S3ClientWrapperFactory {
   public create(transferConfig: TransferConfig): S3ClientWrapper {
     assertS3TransferConfig(transferConfig);

--- a/storage/s3/src/test/unit/backend/CommonUnitTestUtils.ts
+++ b/storage/s3/src/test/unit/backend/CommonUnitTestUtils.ts
@@ -2,14 +2,11 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Container } from "inversify";
+
 import { createStubInstance } from "sinon";
 
-import {
-  Types as CoreTypes,
-  PresignedUrlProvider,
-  TransferConfigProvider,
-} from "@itwin/object-storage-core";
+import { DIContainer } from "@itwin/cloud-agnostic-core";
+import { Types as CoreTypes } from "@itwin/object-storage-core";
 import {
   mockPresignedUrlProvider,
   mockTransferConfigProvider,
@@ -40,22 +37,29 @@ export const s3TestConfig = {
   },
 };
 
-export function rebindS3Server(container: Container): void {
+export function rebindS3Server(container: DIContainer): void {
   const mockS3ClientWrapper = createStubInstance(S3ClientWrapper);
 
-  container.rebind(S3ClientWrapper).toConstantValue(mockS3ClientWrapper);
-  container
-    .rebind<PresignedUrlProvider>(CoreTypes.Server.presignedUrlProvider)
-    .toConstantValue(mockPresignedUrlProvider);
-  container
-    .rebind<TransferConfigProvider>(CoreTypes.Server.transferConfigProvider)
-    .toConstantValue(mockTransferConfigProvider);
+  container.unregister(S3ClientWrapper);
+  container.registerInstance(S3ClientWrapper, mockS3ClientWrapper);
+  container.unregister(CoreTypes.Server.presignedUrlProvider);
+  container.registerInstance(
+    CoreTypes.Server.presignedUrlProvider,
+    mockPresignedUrlProvider
+  );
+  container.unregister(CoreTypes.Server.transferConfigProvider);
+  container.registerInstance(
+    CoreTypes.Server.transferConfigProvider,
+    mockTransferConfigProvider
+  );
 }
 
-export function rebindS3Client(container: Container): void {
+export function rebindS3Client(container: DIContainer): void {
   const mockS3ClientWrapperFactory = createStubInstance(S3ClientWrapperFactory);
 
-  container
-    .rebind(CoreTypes.Client.clientWrapperFactory)
-    .toConstantValue(mockS3ClientWrapperFactory);
+  container.unregister(CoreTypes.Client.clientWrapperFactory);
+  container.registerInstance(
+    CoreTypes.Client.clientWrapperFactory,
+    mockS3ClientWrapperFactory
+  );
 }

--- a/storage/s3/src/test/unit/backend/RunCommonUnitTests.ts
+++ b/storage/s3/src/test/unit/backend/RunCommonUnitTests.ts
@@ -3,8 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import "reflect-metadata";
-import { Container } from "inversify";
 
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 import { StorageUnitTests } from "@itwin/object-storage-tests-backend-unit";
 
 import { S3ClientStorageBindings } from "../../../client";
@@ -21,7 +21,7 @@ import {
 
 class TestS3ServerStorageBindings extends S3ServerStorageBindings {
   public override register(
-    container: Container,
+    container: DIContainer,
     config: S3ServerStorageBindingsConfig
   ): void {
     super.register(container, config);
@@ -30,7 +30,7 @@ class TestS3ServerStorageBindings extends S3ServerStorageBindings {
 }
 
 class TestS3ClientStorageBindings extends S3ClientStorageBindings {
-  public override register(container: Container): void {
+  public override register(container: DIContainer): void {
     super.register(container);
     rebindS3Client(container);
   }

--- a/storage/s3/src/test/unit/backend/RunCommonUnitTests.ts
+++ b/storage/s3/src/test/unit/backend/RunCommonUnitTests.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import { DIContainer } from "@itwin/cloud-agnostic-core";
 import { StorageUnitTests } from "@itwin/object-storage-tests-backend-unit";
 

--- a/storage/s3/src/test/unit/backend/S3ClientStorageBindings.test.ts
+++ b/storage/s3/src/test/unit/backend/S3ClientStorageBindings.test.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import "reflect-metadata";
 
-import { Container } from "inversify";
-
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 import { ClientStorage, Types as CoreTypes } from "@itwin/object-storage-core";
 import {
   DependencyBindingsTestCase,
@@ -22,15 +21,15 @@ describe(`${S3ClientStorageBindings.name}`, () => {
     const bindingsTestCases: DependencyBindingsTestCase[] = [
       {
         testedClassIdentifier: CoreTypes.Client.clientWrapperFactory.toString(),
-        testedFunction: (container: Container) =>
-          container.get<S3ClientWrapperFactory>(
+        testedFunction: (c: DIContainer) =>
+          c.resolve<S3ClientWrapperFactory>(
             CoreTypes.Client.clientWrapperFactory
           ),
         expectedCtor: S3ClientWrapperFactory,
       },
       {
         testedClassIdentifier: ClientStorage.name,
-        testedFunction: (container: Container) => container.get(ClientStorage),
+        testedFunction: (c: DIContainer) => c.resolve(ClientStorage),
         expectedCtor: S3ClientStorage,
       },
     ];

--- a/storage/s3/src/test/unit/backend/S3ClientStorageBindings.test.ts
+++ b/storage/s3/src/test/unit/backend/S3ClientStorageBindings.test.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import { DIContainer } from "@itwin/cloud-agnostic-core";
 import { ClientStorage, Types as CoreTypes } from "@itwin/object-storage-core";
 import {

--- a/storage/s3/src/test/unit/backend/S3ServerStorageBindings.test.ts
+++ b/storage/s3/src/test/unit/backend/S3ServerStorageBindings.test.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 import { S3Client } from "@aws-sdk/client-s3";
 import { STSClient } from "@aws-sdk/client-sts";
-import { Container } from "inversify";
 
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 import {
   Types as CoreTypes,
   PresignedUrlProvider,
@@ -105,41 +105,39 @@ describe(`${S3ServerStorageBindings.name}`, () => {
     const bindingsTestCases: DependencyBindingsTestCase[] = [
       {
         testedClassIdentifier: Types.S3Server.config.toString(),
-        testedFunction: (container: Container) =>
-          container.get<S3ServerStorageConfig>(Types.S3Server.config),
+        testedFunction: (c: DIContainer) =>
+          c.resolve<S3ServerStorageConfig>(Types.S3Server.config),
         expectedCtor: Object,
       },
       {
         testedClassIdentifier: ServerStorage.name,
-        testedFunction: (container: Container) => container.get(ServerStorage),
+        testedFunction: (c: DIContainer) => c.resolve(ServerStorage),
         expectedCtor: S3ServerStorage,
       },
       {
         testedClassIdentifier: S3Client.name,
-        testedFunction: (container: Container) => container.get(S3Client),
+        testedFunction: (c: DIContainer) => c.resolve(S3Client),
         expectedCtor: S3Client,
       },
       {
         testedClassIdentifier: STSClient.name,
-        testedFunction: (container: Container) => container.get(STSClient),
+        testedFunction: (c: DIContainer) => c.resolve(STSClient),
         expectedCtor: STSClient,
       },
       {
         testedClassIdentifier: Types.bucket.toString(),
-        testedFunction: (container: Container) =>
-          container.get<string>(Types.bucket),
+        testedFunction: (c: DIContainer) => c.resolve<string>(Types.bucket),
         expectedCtor: String,
       },
       {
         testedClassIdentifier: S3ClientWrapper.name,
-        testedFunction: (container: Container) =>
-          container.get(S3ClientWrapper),
+        testedFunction: (c: DIContainer) => c.resolve(S3ClientWrapper),
         expectedCtor: S3ClientWrapper,
       },
       {
         testedClassIdentifier: CoreTypes.Server.presignedUrlProvider.toString(),
-        testedFunction: (container: Container) =>
-          container.get<PresignedUrlProvider>(
+        testedFunction: (c: DIContainer) =>
+          c.resolve<PresignedUrlProvider>(
             CoreTypes.Server.presignedUrlProvider
           ),
         expectedCtor: S3PresignedUrlProvider,
@@ -147,8 +145,8 @@ describe(`${S3ServerStorageBindings.name}`, () => {
       {
         testedClassIdentifier:
           CoreTypes.Server.transferConfigProvider.toString(),
-        testedFunction: (container: Container) =>
-          container.get<TransferConfigProvider>(
+        testedFunction: (c: DIContainer) =>
+          c.resolve<TransferConfigProvider>(
             CoreTypes.Server.transferConfigProvider
           ),
         expectedCtor: S3TransferConfigProvider,

--- a/storage/s3/src/test/unit/frontend/S3FrontendStorageBindings.test.ts
+++ b/storage/s3/src/test/unit/frontend/S3FrontendStorageBindings.test.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "reflect-metadata";
-
 import {
   Types as CoreTypes,
   FrontendStorage,

--- a/storage/s3/src/test/unit/frontend/S3FrontendStorageBindings.test.ts
+++ b/storage/s3/src/test/unit/frontend/S3FrontendStorageBindings.test.ts
@@ -4,8 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 import "reflect-metadata";
 
-import { Container } from "inversify";
-
 import {
   Types as CoreTypes,
   FrontendStorage,
@@ -14,6 +12,8 @@ import {
   DependencyBindingsTestCase,
   testBindings,
 } from "@itwin/object-storage-tests-backend-unit/lib/shared/test-templates/BindingsTests";
+
+import { DIContainer } from "@itwin/cloud-agnostic-core";
 
 import {
   FrontendS3ClientWrapperFactory,
@@ -29,16 +29,15 @@ describe(`${S3FrontendStorageBindings.name}`, () => {
       {
         testedClassIdentifier:
           CoreTypes.Frontend.clientWrapperFactory.toString(),
-        testedFunction: (container: Container) =>
-          container.get<FrontendS3ClientWrapperFactory>(
+        testedFunction: (c: DIContainer) =>
+          c.resolve<FrontendS3ClientWrapperFactory>(
             CoreTypes.Frontend.clientWrapperFactory
           ),
         expectedCtor: FrontendS3ClientWrapperFactory,
       },
       {
         testedClassIdentifier: FrontendStorage.name,
-        testedFunction: (container: Container) =>
-          container.get(FrontendStorage),
+        testedFunction: (c: DIContainer) => c.resolve(FrontendStorage),
         expectedCtor: S3FrontendStorage,
       },
     ];

--- a/tests/backend-storage-unit/src/StorageUnitTests.ts
+++ b/tests/backend-storage-unit/src/StorageUnitTests.ts
@@ -5,13 +5,15 @@
 import { readdirSync } from "fs";
 import { join } from "path";
 
-import { Container } from "inversify";
 import * as Mocha from "mocha";
+
+import { InversifyWrapper } from "@itwin/cloud-agnostic-core/lib/inversify";
 
 import {
   Bindable,
   Types as CoreTypes,
   DependenciesConfig,
+  DIContainer,
 } from "@itwin/cloud-agnostic-core";
 import {
   ClientStorage,
@@ -23,7 +25,7 @@ import {
 import { setOptions } from "./test/Config";
 
 export class StorageUnitTests extends Bindable {
-  public readonly container = new Container();
+  public readonly container: DIContainer = InversifyWrapper.create();
 
   constructor(
     config: DependenciesConfig,
@@ -38,16 +40,17 @@ export class StorageUnitTests extends Bindable {
     this.useBindings(serverStorageDependency);
     this.useBindings(clientStorageDependency);
 
-    this.container
-      .bind<DependenciesConfig>(CoreTypes.dependenciesConfig)
-      .toConstantValue(config);
+    this.container.registerInstance<DependenciesConfig>(
+      CoreTypes.dependenciesConfig,
+      config
+    );
   }
 
   public async start(): Promise<void> {
     this.bindDependencies(this.container);
 
-    const serverStorage = this.container.get(ServerStorage);
-    const clientStorage = this.container.get(ClientStorage);
+    const serverStorage = this.container.resolve(ServerStorage);
+    const clientStorage = this.container.resolve(ClientStorage);
 
     setOptions({
       serverStorage,

--- a/tests/backend-storage-unit/src/shared/test-templates/BindingsTests.ts
+++ b/tests/backend-storage-unit/src/shared/test-templates/BindingsTests.ts
@@ -3,14 +3,19 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
-import { Container } from "inversify";
 
-import { Dependency, DependencyConfig } from "@itwin/cloud-agnostic-core";
+import { InversifyWrapper } from "@itwin/cloud-agnostic-core/lib/inversify";
+
+import {
+  Dependency,
+  DependencyConfig,
+  DIContainer,
+} from "@itwin/cloud-agnostic-core";
 import { ServerStorageDependency } from "@itwin/object-storage-core";
 
 export interface DependencyBindingsTestCase {
   testedClassIdentifier: string;
-  testedFunction: (container: Container) => unknown;
+  testedFunction: (c: DIContainer) => unknown;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   expectedCtor: new (...args: any[]) => unknown;
 }
@@ -27,7 +32,7 @@ export function testBindings(
 ): void {
   for (const testCase of testCases) {
     it(`should register ${testCase.testedClassIdentifier}`, () => {
-      const container = new Container();
+      const container: DIContainer = InversifyWrapper.create();
       bindings.register(container, config);
 
       const testedFunction = () => testCase.testedFunction(container);
@@ -35,7 +40,7 @@ export function testBindings(
     });
 
     it(`should register ${testCase.testedClassIdentifier} as a singleton`, () => {
-      const container = new Container();
+      const container: DIContainer = InversifyWrapper.create();
       bindings.register(container, config);
       const instance1 = testCase.testedFunction(container);
       const instance2 = testCase.testedFunction(container);
@@ -44,7 +49,7 @@ export function testBindings(
     });
 
     it(`should resolve ${testCase.testedClassIdentifier} to ${testCase.expectedCtor.name}`, () => {
-      const container = new Container();
+      const container: DIContainer = InversifyWrapper.create();
       bindings.register(container, config);
       const instance = testCase.testedFunction(container);
 
@@ -61,7 +66,7 @@ export function testInvalidServerConfig(
 ): void {
   for (const testCase of testCases) {
     it(`should throw if dependency config is invalid (${testCase.expectedErrorMessage})`, () => {
-      const container = new Container();
+      const container: DIContainer = InversifyWrapper.create();
 
       const testedFunction = () =>
         serverBindings.register(container, testCase.config);

--- a/tests/frontend-storage/src/backend/FrontendStorageTestSetup.ts
+++ b/tests/frontend-storage/src/backend/FrontendStorageTestSetup.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Container } from "inversify";
 
+import { InversifyWrapper } from "@itwin/cloud-agnostic-core/lib/inversify";
 import {
   FrontendStorage,
   FrontendStorageDependency,
@@ -13,10 +13,11 @@ import {
   Bindable,
   DependenciesConfig,
   Types as DependencyTypes,
+  DIContainer,
 } from "@itwin/cloud-agnostic-core";
 
 export class FrontendStorageTestSetup extends Bindable {
-  public readonly container = new Container();
+  public readonly container: DIContainer = InversifyWrapper.create();
 
   constructor(
     config: DependenciesConfig,
@@ -28,14 +29,15 @@ export class FrontendStorageTestSetup extends Bindable {
     this.requireDependency(FrontendStorageDependency.dependencyType);
     this.useBindings(frontendStorageDependency);
 
-    this.container
-      .bind<DependenciesConfig>(DependencyTypes.dependenciesConfig)
-      .toConstantValue(config);
+    this.container.registerInstance<DependenciesConfig>(
+      DependencyTypes.dependenciesConfig,
+      config
+    );
   }
 
   public setGlobals(): void {
     this.bindDependencies(this.container);
-    const frontendStorage = this.container.get(FrontendStorage);
+    const frontendStorage = this.container.resolve(FrontendStorage);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).frontendStorage = frontendStorage;

--- a/tests/frontend-storage/src/backend/server-storage-proxy/ServerStorageProxy.ts
+++ b/tests/frontend-storage/src/backend/server-storage-proxy/ServerStorageProxy.ts
@@ -5,9 +5,10 @@
 import * as path from "path";
 
 import * as express from "express";
-import { Container } from "inversify";
 
-import { Bindable } from "@itwin/cloud-agnostic-core";
+import { InversifyWrapper } from "@itwin/cloud-agnostic-core/lib/inversify";
+
+import { Bindable, DIContainer } from "@itwin/cloud-agnostic-core";
 import {
   ServerStorage,
   ServerStorageDependency,
@@ -17,7 +18,7 @@ import {
 import * as Common from "./Common";
 
 export class ServerStorageProxy extends Bindable {
-  public readonly container = new Container();
+  public readonly container: DIContainer = InversifyWrapper.create();
 
   private readonly _contentTypeHeader = "content-type";
   private readonly _contentTypeStream = "application/octet-stream";
@@ -31,7 +32,7 @@ export class ServerStorageProxy extends Bindable {
 
   public start(config: { port: number }): void {
     this.bindDependencies(this.container);
-    const serverStorage = this.container.get(ServerStorage);
+    const serverStorage = this.container.resolve(ServerStorage);
 
     const app = express();
     const publicDir = path.resolve(__dirname, "..", "..", "public");


### PR DESCRIPTION
Make inversify optional. iTwin.js team has moved inversify to optional peer dependencies, but decorators on all of the classes still made those packages effectively required. Wrapper on top of inversify makes it a bit harder to use but also possible to substitute for any other DI framework that supports child containers and named registrations.