### PR TITLE
Fix AbortSignal

### DIFF
--- a/cloud-agnostic/core/package.json
+++ b/cloud-agnostic/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/cloud-agnostic-core",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Package that allows configuring components loaded by dependency injection",
   "keywords": [
     "Bentley",

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -2,7 +2,7 @@
   {
     "definitionName": "lockStepVersion",
     "policyName": "lockStepVersionObjectStorage",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "nextBump": "prerelease"
   }
 ]

--- a/storage/azure/package.json
+++ b/storage/azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/object-storage-azure",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Object storage implementation using Azure Blob Storage",
   "keywords": [
     "Bentley",

--- a/storage/core/package.json
+++ b/storage/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/object-storage-core",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Core generic object storage interfaces",
   "keywords": [
     "Bentley",

--- a/storage/core/src/common/AbortSignal.ts
+++ b/storage/core/src/common/AbortSignal.ts
@@ -16,9 +16,19 @@ export interface GenericAbortSignal {
 
 export function createClientAbortSignal(
   userAbortSignal: GenericAbortSignal
-): GenericAbortSignal {
-  const signal = AbortSignal.any([
-    userAbortSignal as AbortSignal,
-  ]) as unknown as GenericAbortSignal;
-  return signal;
+): AbortSignal {
+  if (userAbortSignal.aborted) {
+    return AbortSignal.abort();
+  }
+
+  const controller = new AbortController();
+
+  const abortListener = () => {
+    userAbortSignal.removeEventListener("abort", abortListener);
+    controller.abort();
+  };
+
+  userAbortSignal.addEventListener("abort", abortListener);
+
+  return controller.signal;
 }

--- a/storage/google/package.json
+++ b/storage/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/object-storage-google",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Object storage implementation using Google Cloud Storage",
   "keywords": [
     "Bentley",

--- a/storage/minio/package.json
+++ b/storage/minio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/object-storage-minio",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Object storage implementation using Minio",
   "keywords": [
     "Bentley",

--- a/storage/oss/package.json
+++ b/storage/oss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/object-storage-oss",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Object storage implementation using OSS",
   "keywords": [
     "Bentley",

--- a/storage/s3/package.json
+++ b/storage/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/object-storage-s3",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Object storage implementation base for S3 compatible providers",
   "keywords": [
     "Bentley",

--- a/tests/backend-storage/src/common-tests/ClientStorage.test.ts
+++ b/tests/backend-storage/src/common-tests/ClientStorage.test.ts
@@ -189,7 +189,6 @@ describe(`${ClientStorage.name}: ${clientStorage.constructor.name}`, () => {
         const downloadUrl = await serverStorage.getDownloadUrl(uploadedFile);
         const abortController = new AbortController();
 
-        abortController.abort();
         const downloadPromise = clientStorage.download({
           storageType: storageType,
           url: downloadUrl,
@@ -197,6 +196,7 @@ describe(`${ClientStorage.name}: ${clientStorage.constructor.name}`, () => {
           localPath: `${testDownloadPath}/download-url.txt`,
           abortSignal: abortController.signal,
         });
+        abortController.abort();
 
         let wasAborted = false;
         try {
@@ -529,7 +529,6 @@ describe(`${ClientStorage.name}: ${clientStorage.constructor.name}`, () => {
             );
           const abortController = new AbortController();
 
-          abortController.abort();
           const downloadPromise = clientStorage.download({
             reference: uploadedFile,
             transferConfig: downloadConfig,
@@ -537,6 +536,7 @@ describe(`${ClientStorage.name}: ${clientStorage.constructor.name}`, () => {
             localPath: path.join(testDownloadPath, "download-config.txt"),
             abortSignal: abortController.signal,
           });
+          abortController.abort();
 
           let wasAborted = false;
           try {


### PR DESCRIPTION
AbortSignal.any was not working properly in clients, switching to AbortController-based implementation.